### PR TITLE
Use MDI icons in profile card and switch proxy groups to accordion; hide `hidden: true` groups

### DIFF
--- a/design/src/main/java/com/github/kr328/clash/design/ProxyDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ProxyDesign.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.view.View
 import android.widget.Toast
-import androidx.viewpager2.widget.ViewPager2
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.kr328.clash.core.model.Proxy
 import com.github.kr328.clash.core.model.TunnelState
 import com.github.kr328.clash.design.adapter.ProxyAdapter
-import com.github.kr328.clash.design.adapter.ProxyPageAdapter
+import com.github.kr328.clash.design.adapter.ProxyGroupAdapter
 import com.github.kr328.clash.design.component.ProxyMenu
 import com.github.kr328.clash.design.component.ProxyViewConfig
 import com.github.kr328.clash.design.databinding.DesignProxyBinding
@@ -18,7 +18,7 @@ import com.github.kr328.clash.design.util.applyFrom
 import com.github.kr328.clash.design.util.layoutInflater
 import com.github.kr328.clash.design.util.resolveThemedColor
 import com.github.kr328.clash.design.util.root
-import com.google.android.material.tabs.TabLayoutMediator
+import com.github.kr328.clash.design.util.swapDataSet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -46,20 +46,32 @@ class ProxyDesign(
     private val menu: ProxyMenu by lazy {
         ProxyMenu(context, binding.menuView, overrideMode, uiStore, requests) {
             config.proxyLine = uiStore.proxyLine
+            binding.groupListView.adapter?.notifyDataSetChanged()
         }
     }
 
-    private val adapter: ProxyPageAdapter
-        get() = binding.pagesView.adapter!! as ProxyPageAdapter
-
-    private var horizontalScrolling = false
-    private val verticalBottomScrolled: Boolean
-        get() = adapter.states[binding.pagesView.currentItem].bottom
-    private var urlTesting: Boolean
-        get() = adapter.states[binding.pagesView.currentItem].urlTesting
-        set(value) {
-            adapter.states[binding.pagesView.currentItem].urlTesting = value
+    private val proxyAdapters = List(groupNames.size) { index ->
+        ProxyAdapter(config) { name ->
+            requests.trySend(Request.Select(index, name))
         }
+    }
+
+    private val groupAdapter = ProxyGroupAdapter(
+        config,
+        groupNames,
+        proxyAdapters,
+    ) { index ->
+        uiStore.proxyLastGroup = groupNames[index]
+        currentGroupIndex = index
+    }
+
+    private var urlTesting: Boolean
+        get() = urlTestingState
+        set(value) {
+            urlTestingState = value
+        }
+    private var urlTestingState = false
+    private var currentGroupIndex = 0
 
     override val root: View = binding.root
 
@@ -70,16 +82,27 @@ class ProxyDesign(
         parent: ProxyState,
         links: Map<String, ProxyState>
     ) {
-        adapter.updateAdapter(position, proxies, selectable, parent, links)
+        val states = withContext(Dispatchers.Default) {
+            proxies.map {
+                val link = if (it.type.group) links[it.name] else null
 
-        adapter.states[position].urlTesting = false
+                com.github.kr328.clash.design.component.ProxyViewState(config, it, parent, link)
+            }
+        }
+
+        withContext(Dispatchers.Main) {
+            proxyAdapters[position].apply {
+                this.selectable = selectable
+                this.swapDataSet(this::states, states, false)
+            }
+        }
 
         updateUrlTestButtonStatus()
     }
 
     suspend fun requestRedrawVisible() {
         withContext(Dispatchers.Main) {
-            adapter.requestRedrawVisible()
+            binding.groupListView.invalidate()
         }
     }
 
@@ -102,65 +125,32 @@ class ProxyDesign(
             binding.emptyView.visibility = View.VISIBLE
 
             binding.urlTestView.visibility = View.GONE
-            binding.tabLayoutView.visibility = View.GONE
             binding.elevationView.visibility = View.GONE
-            binding.pagesView.visibility = View.GONE
+            binding.groupListView.visibility = View.GONE
             binding.urlTestFloatView.visibility = View.GONE
         } else {
             binding.urlTestFloatView.supportImageTintList = ColorStateList.valueOf(
                 context.resolveThemedColor(com.google.android.material.R.attr.colorOnPrimary)
             )
 
-            binding.pagesView.apply {
-                adapter = ProxyPageAdapter(
-                    surface,
-                    config,
-                    List(groupNames.size) { index ->
-                        ProxyAdapter(config) { name ->
-                            requests.trySend(Request.Select(index, name))
-                        }
-                    }
-                ) {
-                    if (it == currentItem)
-                        updateUrlTestButtonStatus()
-                }
-
-                registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
-                    override fun onPageScrollStateChanged(state: Int) {
-                        horizontalScrolling = state != ViewPager2.SCROLL_STATE_IDLE
-
-                        updateUrlTestButtonStatus()
-                    }
-
-                    override fun onPageSelected(position: Int) {
-                        uiStore.proxyLastGroup = groupNames[position]
-                    }
-                })
-            }
-
-            TabLayoutMediator(binding.tabLayoutView, binding.pagesView) { tab, index ->
-                tab.text = groupNames[index]
-            }.attach()
+            binding.groupListView.layoutManager = LinearLayoutManager(context)
+            binding.groupListView.adapter = groupAdapter
 
             val initialPosition = groupNames.indexOf(uiStore.proxyLastGroup)
-
-            binding.pagesView.post {
-                if (initialPosition > 0)
-                    binding.pagesView.setCurrentItem(initialPosition, false)
-            }
+            currentGroupIndex = if (initialPosition >= 0) initialPosition else 0
         }
     }
 
     fun requestUrlTesting() {
         urlTesting = true
 
-        requests.trySend(Request.UrlTest(binding.pagesView.currentItem))
+        requests.trySend(Request.UrlTest(currentGroupIndex))
 
         updateUrlTestButtonStatus()
     }
 
     private fun updateUrlTestButtonStatus() {
-        if (verticalBottomScrolled || horizontalScrolling || urlTesting) {
+        if (urlTesting) {
             binding.urlTestFloatView.hide()
         } else {
             binding.urlTestFloatView.show()

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProxyGroupAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProxyGroupAdapter.kt
@@ -45,7 +45,7 @@ class ProxyGroupAdapter(
         val binding = holder.binding
         val expanded = expandedStates[position]
 
-        binding.groupName = groupNames[position]
+        binding.groupTitle = groupNames[position]
         binding.proxyList.adapter = adapters[position]
         binding.proxyList.visibility = if (expanded) View.VISIBLE else View.GONE
         binding.expandIcon.rotation = if (expanded) 90f else 0f

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProxyGroupAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProxyGroupAdapter.kt
@@ -1,0 +1,62 @@
+package com.github.kr328.clash.design.adapter
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.github.kr328.clash.design.component.ProxyViewConfig
+import com.github.kr328.clash.design.databinding.AdapterProxyGroupBinding
+import com.github.kr328.clash.design.util.layoutInflater
+
+class ProxyGroupAdapter(
+    private val config: ProxyViewConfig,
+    private val groupNames: List<String>,
+    private val adapters: List<ProxyAdapter>,
+    private val onGroupToggled: (Int) -> Unit,
+) : RecyclerView.Adapter<ProxyGroupAdapter.Holder>() {
+    class Holder(val binding: AdapterProxyGroupBinding) : RecyclerView.ViewHolder(binding.root)
+
+    private val expandedStates = MutableList(groupNames.size) { index -> index == 0 }
+    private val proxyPool = RecyclerView.RecycledViewPool()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
+        val binding = AdapterProxyGroupBinding.inflate(parent.context.layoutInflater, parent, false)
+        binding.proxyList.apply {
+            layoutManager = GridLayoutManager(context, 6).apply {
+                spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
+                    override fun getSpanSize(position: Int): Int {
+                        val grids = when (config.proxyLine) {
+                            2 -> 3
+                            3 -> 2
+                            else -> 6
+                        }
+                        return if (config.proxyLine == 1) 6 else grids
+                    }
+                }
+            }
+            setRecycledViewPool(proxyPool)
+            clipToPadding = false
+            isNestedScrollingEnabled = false
+        }
+        return Holder(binding)
+    }
+
+    override fun onBindViewHolder(holder: Holder, position: Int) {
+        val binding = holder.binding
+        val expanded = expandedStates[position]
+
+        binding.groupName = groupNames[position]
+        binding.proxyList.adapter = adapters[position]
+        binding.proxyList.visibility = if (expanded) View.VISIBLE else View.GONE
+        binding.expandIcon.rotation = if (expanded) 90f else 0f
+
+        binding.groupHeader.setOnClickListener {
+            val next = !expandedStates[position]
+            expandedStates[position] = next
+            notifyItemChanged(position)
+            onGroupToggled(position)
+        }
+    }
+
+    override fun getItemCount(): Int = groupNames.size
+}

--- a/design/src/main/res/drawable/ic_mdi_arrange_bring_forward.xml
+++ b/design/src/main/res/drawable/ic_mdi_arrange_bring_forward.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,4h10a2,2 0,0 1,2 2v10h-2V6H4V4z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M8,8h12v12H8z" />
+</vector>

--- a/design/src/main/res/drawable/ic_mdi_calendar_alert.xml
+++ b/design/src/main/res/drawable/ic_mdi_calendar_alert.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,2V4H5C3.9,4 3,4.9 3,6V20C3,21.1 3.9,22 5,22H19C20.1,22 21,21.1 21,20V6C21,4.9 20.1,4 19,4H17V2H15V4H9V2H7ZM5,8H19V20H5V8Z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,11a1,1 0,0 1,1 1v4a1,1 0,0 1,-2 0v-4a1,1 0,0 1,1 -1z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,18a1.2,1.2 0,1 1,0 -2.4a1.2,1.2 0,0 1,0 2.4z" />
+</vector>

--- a/design/src/main/res/drawable/ic_mdi_chart_timeline_variant.xml
+++ b/design/src/main/res/drawable/ic_mdi_chart_timeline_variant.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M4,18L10,12L15,15L20,9"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,18m-2,0a2,2 0,1 0,4 0a2,2 0,1 0,-4 0" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,12m-2,0a2,2 0,1 0,4 0a2,2 0,1 0,-4 0" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,15m-2,0a2,2 0,1 0,4 0a2,2 0,1 0,-4 0" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,9m-2,0a2,2 0,1 0,4 0a2,2 0,1 0,-4 0" />
+</vector>

--- a/design/src/main/res/drawable/ic_mdi_database_check.xml
+++ b/design/src/main/res/drawable/ic_mdi_database_check.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,6C4,4.9 7.1,4 12,4C16.9,4 20,4.9 20,6C20,7.1 16.9,8 12,8C7.1,8 4,7.1 4,6Z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,6V18C4,19.1 7.1,20 12,20C16.9,20 20,19.1 20,18V6H18V17.3C18,17.8 15.3,18.5 12,18.5C8.7,18.5 6,17.8 6,17.3V6H4Z" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M9,13L11,15L15,11"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/design/src/main/res/drawable/ic_mdi_update.xml
+++ b/design/src/main/res/drawable/ic_mdi_update.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,10.12h-6.78l2.74,-2.82c-2.73,-2.7 -7.15,-2.8 -9.88,-0.1c-2.73,2.71 -2.73,7.08 0,9.79s7.15,2.71 9.88,0C18.32,15.65 19,14.08 19,12.1h2c0,1.98 -0.88,4.55 -2.64,6.29c-3.51,3.48 -9.21,3.48 -12.72,0c-3.5,-3.47 -3.53,-9.11 -0.02,-12.58s9.14,-3.47 12.65,0L21,3V10.12zM12.5,8v4.25l3.5,2.08l-0.72,1.21L11,13V8H12.5z" />
+</vector>

--- a/design/src/main/res/layout/adapter_profile.xml
+++ b/design/src/main/res/layout/adapter_profile.xml
@@ -67,8 +67,15 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="horizontal"
-                >
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="14dp"
+                    android:layout_height="14dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginEnd="4dp"
+                    android:src="@drawable/ic_mdi_chart_timeline_variant"
+                    android:visibility="@{profile.download &lt;2 ? View.GONE : View.VISIBLE}" />
 
                 <TextView
                     android:textSize="12sp"
@@ -78,6 +85,15 @@
                     android:text='@{profile.download >1  ?I18nKt.toBytesString(profile.download+profile.upload)+"/" :""}'
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
 
+                <ImageView
+                    android:layout_width="14dp"
+                    android:layout_height="14dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="4dp"
+                    android:src="@drawable/ic_mdi_database_check"
+                    android:visibility="@{profile.download &lt;2 ? View.GONE : View.VISIBLE}" />
+
                 <TextView
                     android:textSize="12sp"
                     android:layout_width="wrap_content"
@@ -86,13 +102,27 @@
                     android:text='@{profile.total >1 ?I18nKt.toBytesString(profile.total) : ""}'
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
             </LinearLayout>
-            <TextView
-                android:textSize="12sp"
+
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:visibility="@{profile.expire==0 ? View.GONE : View.VISIBLE}"
-                android:text='@{profile.expire>0 ? I18nKt.toDateStr(profile.expire):""}'
-                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+                android:orientation="horizontal"
+                android:visibility="@{profile.expire==0 ? View.GONE : View.VISIBLE}">
+
+                <ImageView
+                    android:layout_width="14dp"
+                    android:layout_height="14dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginEnd="4dp"
+                    android:src="@drawable/ic_mdi_calendar_alert" />
+
+                <TextView
+                    android:textSize="12sp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text='@{profile.expire>0 ? I18nKt.toDateStr(profile.expire):""}'
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+            </LinearLayout>
             <ProgressBar
                 style="?android:attr/progressBarStyleHorizontal"
                 android:layout_width="match_parent"
@@ -103,15 +133,28 @@
                 />
         </LinearLayout>
 
-        <TextView
+        <LinearLayout
             android:id="@+id/elapsed_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
             android:layout_marginEnd="@dimen/item_midden_margin"
             android:layout_toStartOf="@id/menu_view"
-            android:text="@{IntervalKt.elapsedIntervalString(currentTime.value - profile.updatedAt, context)}"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Tooltip" />
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="14dp"
+                android:layout_height="14dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginEnd="4dp"
+                android:src="@drawable/ic_mdi_update" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@{IntervalKt.elapsedIntervalString(currentTime.value - profile.updatedAt, context)}"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Tooltip" />
+        </LinearLayout>
 
         <View
             android:layout_width="2dp"
@@ -135,7 +178,7 @@
                 android:layout_width="@dimen/item_tailing_component_size"
                 android:layout_height="@dimen/item_tailing_component_size"
                 android:layout_margin="@dimen/item_tailing_margin"
-                android:background="@drawable/ic_baseline_more_vert" />
+                android:background="@drawable/ic_mdi_arrange_bring_forward" />
         </FrameLayout>
     </RelativeLayout>
 </layout>

--- a/design/src/main/res/layout/adapter_proxy_group.xml
+++ b/design/src/main/res/layout/adapter_proxy_group.xml
@@ -2,7 +2,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
     <data>
         <variable
-            name="groupName"
+            name="groupTitle"
             type="String" />
     </data>
 
@@ -29,7 +29,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="@{groupName}"
+                android:text="@{groupTitle}"
                 android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
 
             <ImageView

--- a/design/src/main/res/layout/adapter_proxy_group.xml
+++ b/design/src/main/res/layout/adapter_proxy_group.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+        <variable
+            name="groupName"
+            type="String" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/item_header_margin"
+        android:layout_marginVertical="5dp"
+        android:background="@drawable/bg_b"
+        android:elevation="5dp"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/group_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingHorizontal="@dimen/item_header_margin"
+            android:paddingVertical="@dimen/item_padding_vertical">
+
+            <TextView
+                android:id="@+id/group_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@{groupName}"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+            <ImageView
+                android:id="@+id/expand_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:contentDescription="@string/expand"
+                android:src="@drawable/ic_mdi_arrange_bring_forward" />
+        </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/proxy_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:paddingBottom="@dimen/item_padding_vertical"
+            android:visibility="gone" />
+    </LinearLayout>
+</layout>

--- a/design/src/main/res/layout/design_proxy.xml
+++ b/design/src/main/res/layout/design_proxy.xml
@@ -22,11 +22,13 @@
             android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
             android:visibility="gone" />
 
-        <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/pages_view"
+        <com.github.kr328.clash.design.view.AppRecyclerView
+            android:id="@+id/group_list_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="horizontal" />
+            android:clipToPadding="false"
+            android:paddingTop="@{(float) self.surface.insets.top + @dimen/toolbar_height}"
+            android:paddingBottom="@{self.surface.insets.bottom}" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -96,15 +98,6 @@
 
                 </RelativeLayout>
             </com.github.kr328.clash.design.view.ActivityBarLayout>
-
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/tab_layout_view"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/tab_layout_height"
-                android:alpha="0.96"
-                android:background="?android:windowBackground"
-                app:tabBackground="@android:color/transparent"
-                app:tabMode="scrollable" />
 
             <View
                 android:id="@+id/elevation_view"

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -3,6 +3,7 @@
     <string name="tap_to_start">Нажмите для запуска</string>
     <string name="running">Запущен</string>
     <string name="format_traffic_forwarded">%s перенаправлено</string>
+    <string name="expand">Развернуть</string>
 
     <string name="proxy">Прокси</string>
     <string name="direct_mode">Прямой режим</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="tap_to_start">Tap to start</string>
     <string name="running">Running</string>
     <string name="format_traffic_forwarded">%s Forwarded</string>
+    <string name="expand">Expand</string>
 
     <string name="proxy">Proxy</string>
     <string name="direct_mode">Direct Mode</string>

--- a/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
@@ -9,6 +9,7 @@ import com.github.kr328.clash.service.data.SelectionDao
 import com.github.kr328.clash.service.remote.IClashManager
 import com.github.kr328.clash.service.remote.ILogObserver
 import com.github.kr328.clash.service.store.ServiceStore
+import com.github.kr328.clash.service.util.importedDir
 import com.github.kr328.clash.service.util.sendOverrideChanged
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -27,7 +28,12 @@ class ClashManager(private val context: Context) : IClashManager,
     }
 
     override fun queryProxyGroupNames(excludeNotSelectable: Boolean): List<String> {
-        return Clash.queryGroupNames(excludeNotSelectable)
+        val names = Clash.queryGroupNames(excludeNotSelectable)
+        val hidden = loadHiddenProxyGroups()
+
+        if (hidden.isEmpty()) return names
+
+        return names.filterNot { it in hidden }
     }
 
     override fun queryProxyGroup(name: String, proxySort: ProxySort): ProxyGroup {
@@ -107,5 +113,86 @@ class ClashManager(private val context: Context) : IClashManager,
                 }
             }
         }
+    }
+
+    private fun loadHiddenProxyGroups(): Set<String> {
+        val activeProfile = store.activeProfile ?: return emptySet()
+        val configFile = context.importedDir
+            .resolve(activeProfile.toString())
+            .resolve("config.yaml")
+
+        if (!configFile.exists()) return emptySet()
+
+        return parseHiddenProxyGroups(configFile.readLines())
+    }
+
+    private fun parseHiddenProxyGroups(lines: List<String>): Set<String> {
+        val hiddenGroups = mutableSetOf<String>()
+        var inProxyGroups = false
+        var currentName: String? = null
+        var currentHidden = false
+
+        fun commitCurrent() {
+            val name = currentName?.takeIf { it.isNotBlank() } ?: return
+            if (currentHidden) hiddenGroups.add(name)
+        }
+
+        for (line in lines) {
+            if (line.isBlank() || line.trimStart().startsWith("#")) continue
+
+            val isTopLevel = line.indexOfFirst { !it.isWhitespace() } == 0
+            val trimmed = line.trimStart()
+
+            if (isTopLevel) {
+                if (trimmed.startsWith("proxy-groups:")) {
+                    inProxyGroups = true
+                    currentName = null
+                    currentHidden = false
+                    continue
+                }
+
+                if (inProxyGroups) {
+                    commitCurrent()
+                    break
+                }
+            }
+
+            if (!inProxyGroups) continue
+
+            if (trimmed.startsWith("-")) {
+                commitCurrent()
+                currentName = null
+                currentHidden = false
+
+                val remainder = trimmed.removePrefix("-").trim()
+                if (remainder.startsWith("name:")) {
+                    currentName = parseYamlValue(remainder.removePrefix("name:"))
+                } else if (remainder.startsWith("hidden:")) {
+                    currentHidden = parseYamlValue(remainder.removePrefix("hidden:"))
+                        .equals("true", ignoreCase = true)
+                }
+                continue
+            }
+
+            if (trimmed.startsWith("name:")) {
+                currentName = parseYamlValue(trimmed.removePrefix("name:"))
+                continue
+            }
+
+            if (trimmed.startsWith("hidden:")) {
+                currentHidden = parseYamlValue(trimmed.removePrefix("hidden:"))
+                    .equals("true", ignoreCase = true)
+            }
+        }
+
+        if (inProxyGroups) {
+            commitCurrent()
+        }
+
+        return hiddenGroups
+    }
+
+    private fun parseYamlValue(value: String): String {
+        return value.trim().trim('"', '\'')
     }
 }


### PR DESCRIPTION
### Motivation
- Make the Android UI consistent with prizrak-box desktop by using MDI-style icons in profile/status UI and to simplify proxy group navigation.  
- Replace the tabbed proxy-groups UI which displayed partial proxy items with an accordion-style group list that can expand/collapse groups.  
- Respect `hidden: true` in profile configuration so proxy groups the profile marks hidden are not shown.

### Description
- Updated profile item layout (`design/src/main/res/layout/adapter_profile.xml`) to show MDI icons left of status texts, add an icon for expiry and update the trailing action icon to `mdi-arrange-bring-forward`, and added new vector drawables (`design/src/main/res/drawable/ic_mdi_*.xml`).
- Replaced the ViewPager/tab implementation with an accordion list: added `adapter_proxy_group.xml` layout, new `ProxyGroupAdapter` (`design/src/main/java/.../ProxyGroupAdapter.kt`), and wired a `group_list_view` RecyclerView in `design_proxy.xml` and `ProxyDesign.kt` to use per-group `ProxyAdapter` instances so each group expands/collapses instead of showing partial proxies.
- Implemented filtering of proxy group names that are marked `hidden: true` by parsing the active profile `config.yaml` in `ClashManager.queryProxyGroupNames(...)` with helpers `loadHiddenProxyGroups`/`parseHiddenProxyGroups` so hidden groups are excluded from the returned list.
- Added strings (`expand`) to default and Russian resources so the new group header icon has a content description.

### Testing
- No automated tests were executed as part of this change; only compile-time/source edits were made and committed (manual UI verification recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989cd7cd338832d947de84c859ebc27)