### PR TITLE
Embed missing builtin template content for rubundle and davoyan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ gradle-app.setting
 /core/src/premium/golang/.idea/*
 !/core/src/premium/golang/.idea/codeStyles
 
-# Ignore builtin geofiles
-app/src/main/assets
+# Ignore builtin geofiles (but keep templates)
+app/src/main/assets/*
+!app/src/main/assets/templates/
+!app/src/main/assets/templates/*.yaml
 
 # KeyStore
 signing.properties

--- a/CONVERSION_USAGE.md
+++ b/CONVERSION_USAGE.md
@@ -1,0 +1,225 @@
+# Profile Conversion API Usage
+
+## Overview
+
+The Profile Conversion API provides functionality to convert various proxy profile formats to Clash format.
+
+## Supported Formats
+
+- **Clash/Clash Meta**: Native format (validation only)
+- **Base64**: Base64-encoded proxy lists (ss://, vmess://, trojan://, etc.)
+- **SIP008**: Shadowsocks JSON format
+
+## API Components
+
+### 1. ProfileFormat Enum
+
+```kotlin
+enum class ProfileFormat {
+    CLASH, CLASH_META, BASE64, SHADOWROCKET,
+    V2RAY, SIP008, UNKNOWN, AUTO
+}
+```
+
+### 2. ConvertResult Data Class
+
+```kotlin
+data class ConvertResult(
+    val success: Boolean,
+    val content: String?,
+    val format: String?,
+    val error: String?
+)
+```
+
+### 3. ProfileConverter Object
+
+Main API for profile conversion.
+
+## Usage Examples
+
+### Auto-detect and Convert
+
+```kotlin
+import com.github.kr328.clash.core.bridge.ProfileConverter
+import kotlinx.coroutines.launch
+
+// In a coroutine scope
+launch {
+    val profileContent = """
+        ss://base64encodeddata
+        vmess://base64encodeddata
+    """.trimIndent()
+
+    val result = ProfileConverter.autoConvert(profileContent)
+
+    if (result.isSuccess()) {
+        println("Converted successfully!")
+        println("Detected format: ${result.getDetectedFormat()}")
+        val clashConfig = result.getClashConfig()
+        // Use the config...
+    } else {
+        println("Conversion failed: ${result.getErrorMessage()}")
+    }
+}
+```
+
+### Detect Format Only
+
+```kotlin
+val content = "... profile content ..."
+val format = ProfileConverter.detectFormat(content)
+
+when (format) {
+    ProfileFormat.BASE64 -> println("This is a Base64 subscription")
+    ProfileFormat.SIP008 -> println("This is a SIP008 config")
+    ProfileFormat.CLASH -> println("This is already a Clash config")
+    else -> println("Unknown format")
+}
+```
+
+### Convert Specific Format
+
+```kotlin
+launch {
+    // Convert Base64 subscription
+    val result = ProfileConverter.convertBase64ToClash(base64Content)
+
+    // Convert SIP008
+    val result2 = ProfileConverter.convertSIP008ToClash(sip008Json)
+
+    // Convert with explicit format
+    val result3 = ProfileConverter.convertToClash(
+        content = myContent,
+        sourceFormat = ProfileFormat.BASE64
+    )
+}
+```
+
+### Validate Clash Config
+
+```kotlin
+val clashConfig = """
+port: 7890
+socks-port: 7891
+proxies:
+  - name: test
+    type: ss
+    server: example.com
+    port: 8388
+    cipher: aes-256-gcm
+    password: password
+"""
+
+val result = ProfileConverter.validate(clashConfig)
+if (result.isSuccess()) {
+    println("Valid Clash config!")
+} else {
+    println("Invalid: ${result.getErrorMessage()}")
+}
+
+// Or simple boolean check
+val isValid = ProfileConverter.isValidClashProfile(clashConfig)
+```
+
+### Working with Files
+
+```kotlin
+import com.github.kr328.clash.core.bridge.ProfileUtils
+import java.io.File
+
+// Convert a file
+launch {
+    val inputFile = File("/path/to/subscription.txt")
+    val result = ProfileUtils.convertFileToClash(inputFile)
+
+    if (result.isSuccess()) {
+        val outputFile = File("/path/to/config.yaml")
+        ProfileUtils.saveToFile(result, outputFile)
+    }
+}
+
+// Check if file is valid Clash config
+val configFile = File("/path/to/config.yaml")
+if (ProfileUtils.isValidClashFile(configFile)) {
+    println("Valid Clash config file")
+}
+
+// Detect file format
+val format = ProfileUtils.detectFileFormat(inputFile)
+println("File format: ${ProfileUtils.getFormatDisplayName(format)}")
+```
+
+### Working with Streams
+
+```kotlin
+launch {
+    val inputStream = context.contentResolver.openInputStream(uri)
+    inputStream?.use { stream ->
+        val result = ProfileUtils.convertStreamToClash(stream)
+        // Handle result...
+    }
+}
+```
+
+## Error Handling
+
+All conversion operations return a `ConvertResult` that indicates success or failure:
+
+```kotlin
+val result = ProfileConverter.autoConvert(content)
+
+when {
+    result.isSuccess() -> {
+        // Success
+        val config = result.getClashConfig()
+        processConfig(config)
+    }
+    else -> {
+        // Failure
+        val errorMessage = result.getErrorMessage()
+        showError(errorMessage)
+    }
+}
+```
+
+## Implementation Details
+
+### Stage 1: JNI Bridge Functions (Completed)
+
+- Go functions for profile parsing and conversion
+- C JNI wrappers
+- Native function declarations in Bridge.kt
+
+### Stage 2: Kotlin Wrappers (Completed)
+
+- ProfileFormat enum
+- ConvertResult data class
+- ProfileConverter object with high-level API
+- ProfileUtils for file/stream operations
+
+### Stage 3: Template System (Pending)
+
+Will be implemented with custom logic after Stages 1 and 2 are tested.
+
+## Testing
+
+```kotlin
+// Test auto-detection
+val base64Content = "c3M6Ly8uLi4="
+assert(ProfileConverter.detectFormat(base64Content) == ProfileFormat.BASE64)
+
+// Test conversion
+launch {
+    val result = ProfileConverter.autoConvert(base64Content)
+    assert(result.isSuccess())
+    assert(result.getClashConfig().contains("proxies:"))
+}
+```
+
+## Notes
+
+- All conversion operations run on background threads (Dispatchers.IO)
+- The `convertToClashBlocking` method is deprecated; use the suspend version instead
+- Auto format detection is recommended for user imports
+- Template system (Stage 3) will provide customizable config templates

--- a/app/src/main/assets/templates/davoyan.yaml
+++ b/app/src/main/assets/templates/davoyan.yaml
@@ -1,0 +1,190 @@
+# Davoyan Template for ClashMetaForAndroid
+# Based on Prizrak-Box Template_2
+# Focus: Detailed routing configuration for Russian users
+
+mixed-port: 7890
+allow-lan: true
+tcp-concurrent: true
+enable-process: true
+find-process-mode: always
+mode: rule
+log-level: info
+ipv6: false
+bind-address: "*"
+keep-alive-interval: 30
+unified-delay: false
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  override-destination: false
+  sniff:
+    HTTP:
+      ports:
+        - 80
+        - 8080-8880
+      override-destination: true
+    TLS:
+      ports:
+        - 443
+        - 8443
+
+dns:
+  enable: true
+  prefer-h3: false
+  use-hosts: true
+  use-system-hosts: true
+  ipv6: false
+  enhanced-mode: redir-host
+  default-nameserver:
+    - https://94.140.14.14/dns-query#DIRECT
+    - https://8.8.8.8/dns-query#DIRECT
+  proxy-server-nameserver:
+    - https://94.140.14.14/dns-query#DIRECT
+    - https://8.8.8.8/dns-query#DIRECT
+  direct-nameserver:
+    - 77.88.8.8#DIRECT
+    - 77.88.8.1#DIRECT
+  nameserver:
+    - tls://94.140.14.14#PROXY
+    - tls://94.140.15.15#PROXY
+
+proxies:
+  # Proxies will be injected here from subscription
+
+proxy-groups:
+  - name: Blocked Sites
+    icon: https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/icons/Blocked.png
+    type: select
+    include-all: true
+    proxies:
+      - AUTO
+      - DIRECT
+
+  - name: YouTube
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/YouTube.png
+    type: select
+    include-all: true
+    proxies:
+      - Blocked Sites
+
+  - name: Discord
+    icon: https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/icons/Discord.png
+    type: select
+    include-all: true
+    proxies:
+      - Blocked Sites
+
+  - name: Telegram
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Telegram.png
+    type: select
+    include-all: true
+    proxies:
+      - Blocked Sites
+      - DIRECT
+
+  - name: RU Sites
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Russia.png
+    type: select
+    proxies:
+      - DIRECT
+
+  - name: Other Sites
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Global.png
+    type: select
+    include-all: true
+    proxies:
+      - DIRECT
+      - Blocked Sites
+
+  - name: PROXY
+    type: select
+    hidden: true
+    proxies:
+      - Blocked Sites
+    include-all: true
+
+  - name: AUTO
+    type: url-test
+    hidden: true
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    include-all: true
+
+  - name: DIRECT
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Blackhole.png
+    type: select
+    hidden: true
+    proxies:
+      - DIRECT
+
+rule-providers:
+  geoip-private:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/private.mrs
+    path: ./rule-sets/geoip-private.mrs
+    interval: 86400
+
+  geosite-private:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/private.mrs
+    path: ./rule-sets/geosite-private.mrs
+    interval: 86400
+
+  youtube:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/youtube.mrs
+    path: ./rule-sets/youtube.mrs
+    interval: 86400
+
+  telegram-ips:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/telegram.mrs
+    path: ./rule-sets/telegram-ips.mrs
+    interval: 86400
+
+  telegram-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/telegram.mrs
+    path: ./rule-sets/telegram-domains.mrs
+    interval: 86400
+
+  discord-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/discord.mrs
+    path: ./rule-sets/discord-domains.mrs
+    interval: 86400
+
+  ru-inline:
+    type: http
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/inline/ru-inline.yaml
+    interval: 86400
+    behavior: classical
+    format: yaml
+    path: ./rule-sets/ru-inline.yaml
+
+rules:
+  - RULE-SET,geoip-private,DIRECT,no-resolve
+  - RULE-SET,geosite-private,DIRECT
+  - RULE-SET,youtube,YouTube
+  - OR,((RULE-SET,telegram-ips),(RULE-SET,telegram-domains)),Telegram
+  - RULE-SET,discord-domains,Discord
+  - RULE-SET,ru-inline,RU Sites
+  - MATCH,Other Sites

--- a/app/src/main/assets/templates/default.yaml
+++ b/app/src/main/assets/templates/default.yaml
@@ -1,0 +1,142 @@
+# Default Template for ClashMetaForAndroid
+# Based on Prizrak-Box Template_0
+# Focus: Russian services with basic VPN routing
+
+mixed-port: 7890
+allow-lan: true
+tcp-concurrent: true
+enable-process: true
+find-process-mode: always
+mode: rule
+log-level: info
+ipv6: false
+keep-alive-interval: 30
+unified-delay: true
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  sniff:
+    HTTP:
+      ports:
+        - 80
+        - 8080-8880
+      override-destination: true
+    TLS:
+      ports:
+        - 443
+        - 8443
+
+dns:
+  enable: true
+  prefer-h3: true
+  use-hosts: true
+  use-system-hosts: true
+  ipv6: false
+  enhanced-mode: redir-host
+  default-nameserver:
+    - tls://77.88.8.8#DIRECT
+    - 195.208.4.1#DIRECT
+  nameserver:
+    - https://cloudflare-dns.com/dns-query#PROXY
+    - https://1.1.1.1/dns-query#PROXY
+
+proxies:
+  # Proxies will be injected here from subscription
+
+proxy-groups:
+  - name: PROXY
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Hijacking.png
+    type: select
+    include-all: true
+    proxies:
+      - AUTO
+      # LEAVE THIS LINE!
+
+  - name: AUTO
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Auto.png
+    type: url-test
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    include-all: true
+    proxies:
+      # LEAVE THIS LINE!
+
+  - name: YouTube
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/YouTube.png
+    type: select
+    include-all: true
+    proxies:
+      - PROXY
+      - AUTO
+      # LEAVE THIS LINE!
+
+  - name: DIRECT
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Blackhole.png
+    type: select
+    hidden: true
+    proxies:
+      - DIRECT
+
+rule-providers:
+  ru-inline:
+    type: http
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/inline/ru-inline.yaml
+    interval: 86400
+    behavior: classical
+    format: yaml
+    path: ./rule-sets/ru-inline.yaml
+
+  youtube:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/youtube.mrs
+    path: ./rule-sets/youtube.mrs
+    interval: 86400
+
+  geosite-ru:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/category-ru.mrs
+    path: ./rule-sets/geosite-ru.mrs
+    interval: 86400
+
+  geoip-ru:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/ru.mrs
+    path: ./rule-sets/geoip-ru.mrs
+    interval: 86400
+
+  geosite-private:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/private.mrs
+    path: ./rule-sets/geosite-private.mrs
+    interval: 86400
+
+  geoip-private:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/private.mrs
+    path: ./rule-sets/geoip-private.mrs
+    interval: 86400
+
+rules:
+  - RULE-SET,youtube,YouTube
+  - RULE-SET,geoip-private,DIRECT,no-resolve
+  - RULE-SET,geosite-private,DIRECT
+  - RULE-SET,ru-inline,DIRECT
+  - RULE-SET,geosite-ru,DIRECT
+  - RULE-SET,geoip-ru,DIRECT
+  - MATCH,PROXY

--- a/app/src/main/assets/templates/rubundle.yaml
+++ b/app/src/main/assets/templates/rubundle.yaml
@@ -1,0 +1,155 @@
+# RU Bundle Template for ClashMetaForAndroid
+# Based on Prizrak-Box Template_1
+# Focus: Re:filter + international services (Telegram, Discord, YouTube)
+
+mode: rule
+log-level: info
+mixed-port: 7890
+unified-delay: true
+allow-lan: true
+tcp-concurrent: true
+enable-process: true
+find-process-mode: always
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  sniff:
+    HTTP:
+      ports:
+        - 80
+        - 8080-8880
+      override-destination: true
+    TLS:
+      ports:
+        - 443
+        - 8443
+
+dns:
+  enable: true
+  prefer-h3: true
+  use-hosts: true
+  use-system-hosts: true
+  ipv6: false
+  enhanced-mode: redir-host
+  default-nameserver:
+    - tls://77.88.8.8#DIRECT
+    - 195.208.4.1#DIRECT
+  nameserver:
+    - https://cloudflare-dns.com/dns-query#PROXY
+
+proxies:
+  # Proxies will be injected here from subscription
+
+proxy-groups:
+  - name: PROXY
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Hijacking.png
+    type: select
+    proxies:
+      - AUTO
+      # LEAVE THIS LINE!
+    include-all: true
+
+  - name: YouTube
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/YouTube.png
+    type: select
+    proxies:
+      - PROXY
+      # LEAVE THIS LINE!
+    include-all: true
+
+  - name: Discord
+    icon: https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/icons/Discord.png
+    type: select
+    proxies:
+      - PROXY
+      # LEAVE THIS LINE!
+    include-all: true
+
+  - name: Telegram
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Telegram.png
+    type: select
+    include-all: true
+    proxies:
+      - PROXY
+
+  - name: AUTO
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Auto.png
+    type: url-test
+    tolerance: 150
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    proxies:
+      # LEAVE THIS LINE!
+    include-all: true
+
+rule-providers:
+  telegram-ips:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    interval: 86400
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/telegram.mrs
+    path: ./rule-sets/telegram-ips.mrs
+
+  telegram-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    interval: 86400
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/telegram.mrs
+    path: ./rule-sets/telegram-domains.mrs
+
+  discord-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/discord.mrs
+    path: ./rule-sets/discord-domains.mrs
+    interval: 86400
+
+  refilter-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/re-filter/domain-rule.mrs
+    path: ./rule-sets/refilter-domains.mrs
+    interval: 86400
+
+  refilter-ips:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/re-filter/ip-rule.mrs
+    path: ./rule-sets/refilter-ips.mrs
+    interval: 86400
+
+  youtube:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/youtube.mrs
+    path: ./rule-sets/youtube.mrs
+    interval: 86400
+
+  ru-bundle:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/ru-bundle/rule.mrs
+    path: ./rule-sets/ru-bundle.mrs
+    interval: 86400
+
+rules:
+  - OR,((RULE-SET,telegram-ips),(RULE-SET,telegram-domains)),Telegram
+  - RULE-SET,youtube,YouTube
+  - RULE-SET,discord-domains,Discord
+  - RULE-SET,ru-bundle,PROXY
+  - RULE-SET,refilter-domains,PROXY
+  - RULE-SET,refilter-ips,PROXY
+  - MATCH,DIRECT

--- a/app/src/main/java/com/github/kr328/clash/NewProfileActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/NewProfileActivity.kt
@@ -5,6 +5,8 @@ import android.content.ComponentName
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import com.github.kr328.clash.core.bridge.TemplatesBridge
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
 import com.github.kr328.clash.common.constants.Intents
@@ -28,6 +30,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withContext
 import java.util.*
+import kotlin.coroutines.resume
 
 class NewProfileActivity : BaseActivity<NewProfileDesign>() {
     private val self: NewProfileActivity
@@ -81,8 +84,13 @@ class NewProfileActivity : BaseActivity<NewProfileDesign>() {
                                     }
                                 }
 
-                                if (uuid != null)
+                                if (uuid != null) {
+                                    val templateId = requestTemplateSelection()
+                                    if (templateId != null) {
+                                        writeInitialTemplate(uuid, templateId)
+                                    }
                                     launchProperties(uuid)
+                                }
                             }
                         }
 
@@ -99,6 +107,46 @@ class NewProfileActivity : BaseActivity<NewProfileDesign>() {
         }
     }
 
+
+
+    private suspend fun requestTemplateSelection(): String? {
+        val templates = TemplatesBridge.getAvailableTemplates()
+        if (templates.isEmpty()) {
+            design?.showExceptionToast(getString(R.string.error))
+            return null
+        }
+
+        val names = templates.map { it.name }.toTypedArray()
+        val ids = templates.map { it.id }
+
+        return kotlinx.coroutines.suspendCancellableCoroutine<String?> { cont ->
+            var selected = 0
+            val dialog = MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.template_select_title)
+                .setSingleChoiceItems(names, 0) { _, which -> selected = which }
+                .setPositiveButton(R.string.ok) { _, _ -> cont.resume(ids[selected]) }
+                .setNegativeButton(R.string.cancel) { _, _ -> cont.resume("default") }
+                .setOnCancelListener { if (!cont.isCompleted) cont.resume("default") }
+                .create()
+
+            cont.invokeOnCancellation { dialog.dismiss() }
+            dialog.show()
+        }
+    }
+
+    private fun writeInitialTemplate(uuid: UUID, templateId: String) {
+        val profileDir = filesDir.resolve("pending").resolve(uuid.toString())
+        profileDir.mkdirs()
+        profileDir.resolve("template.txt").writeText(templateId)
+
+        if (templateId == "custom") {
+            val customFile = profileDir.resolve("custom-template.yaml")
+            if (!customFile.exists()) {
+                val fallback = assets.open("templates/default.yaml").use { it.bufferedReader().readText() }
+                customFile.writeText(fallback)
+            }
+        }
+    }
     private fun launchAppDetailed(provider: ProfileProvider.External) {
         val data = Uri.fromParts(
             "package",
@@ -187,13 +235,16 @@ class NewProfileActivity : BaseActivity<NewProfileDesign>() {
 
     private suspend fun createProfileByQrCode(url: String) {
         withProfile {
-            launchProperties(
-                create(
-                    type = Profile.Type.Url,
-                    name = getString(R.string.new_profile),
-                    url,
-                )
+            val uuid = create(
+                type = Profile.Type.Url,
+                name = getString(R.string.new_profile),
+                url,
             )
+
+            val templateId = requestTemplateSelection() ?: "default"
+            writeInitialTemplate(uuid, templateId)
+
+            launchProperties(uuid)
         }
     }
 

--- a/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
@@ -1,18 +1,27 @@
 package com.github.kr328.clash
 
+import android.text.InputType
 import com.github.kr328.clash.common.util.intent
 import com.github.kr328.clash.common.util.setUUID
 import com.github.kr328.clash.common.util.uuid
+import com.github.kr328.clash.core.bridge.TemplatesBridge
 import com.github.kr328.clash.design.PropertiesDesign
+import com.github.kr328.clash.design.R
+import com.github.kr328.clash.design.databinding.DialogTextFieldBinding
 import com.github.kr328.clash.design.ui.ToastDuration
 import com.github.kr328.clash.design.util.showExceptionToast
 import com.github.kr328.clash.service.model.Profile
+import com.github.kr328.clash.service.util.importedDir
+import com.github.kr328.clash.service.util.pendingDir
 import com.github.kr328.clash.util.withProfile
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
-import com.github.kr328.clash.design.R
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.UUID
+import kotlin.coroutines.resume
 
 class PropertiesActivity : BaseActivity<PropertiesDesign>() {
     private var canceled: Boolean = false
@@ -27,6 +36,7 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
         original = withProfile { queryByUUID(uuid) } ?: return finish()
 
         design.profile = original
+        design.selectedTemplateName = getTemplateDisplayName(readCurrentTemplateId(uuid))
 
         setContentDesign(design)
 
@@ -49,19 +59,31 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
                                 }
                             }
                         }
+
                         Event.ServiceRecreated -> {
                             finish()
                         }
+
                         else -> Unit
                     }
                 }
+
                 design.requests.onReceive {
                     when (it) {
                         PropertiesDesign.Request.BrowseFiles -> {
                             startActivity(FilesActivity::class.intent.setUUID(uuid))
                         }
+
                         PropertiesDesign.Request.Commit -> {
                             design.verifyAndCommit()
+                        }
+
+                        PropertiesDesign.Request.SelectTemplate -> {
+                            selectTemplate(uuid, design)
+                        }
+
+                        PropertiesDesign.Request.EditCustomTemplate -> {
+                            editCustomTemplate(uuid)
                         }
                     }
                 }
@@ -85,9 +107,11 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
             profile.name.isBlank() -> {
                 showToast(R.string.empty_name, ToastDuration.Long)
             }
+
             profile.type != Profile.Type.File && profile.source.isBlank() -> {
                 showToast(R.string.invalid_url, ToastDuration.Long)
             }
+
             else -> {
                 try {
                     withProcessing { updateStatus ->
@@ -116,6 +140,113 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
                     showExceptionToast(e)
                 }
             }
+        }
+    }
+
+    private suspend fun selectTemplate(uuid: UUID, design: PropertiesDesign) {
+        val templates = TemplatesBridge.getAvailableTemplates()
+        if (templates.isEmpty()) {
+            showToast(R.string.error, ToastDuration.Long)
+            return
+        }
+
+        val currentId = readCurrentTemplateId(uuid)
+        val names = templates.map { it.name }.toTypedArray()
+        val ids = templates.map { it.id }
+        val selected = suspendCancellableCoroutine<String?> { cont ->
+            var selectedIndex = ids.indexOf(currentId).coerceAtLeast(0)
+            val dialog = MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.template_select_title)
+                .setSingleChoiceItems(names, selectedIndex) { _, which ->
+                    selectedIndex = which
+                }
+                .setPositiveButton(R.string.ok) { _, _ ->
+                    cont.resume(ids[selectedIndex])
+                }
+                .setNegativeButton(R.string.cancel) { _, _ ->
+                    cont.resume(null)
+                }
+                .setOnCancelListener {
+                    if (!cont.isCompleted) cont.resume(null)
+                }
+                .create()
+
+            cont.invokeOnCancellation { dialog.dismiss() }
+            dialog.show()
+        } ?: return
+
+        writeTemplateId(uuid, selected)
+        design.selectedTemplateName = getTemplateDisplayName(selected)
+        showToast(R.string.template_saved, ToastDuration.Short)
+    }
+
+    private suspend fun editCustomTemplate(uuid: UUID) {
+        val profileDir = ensureWritableProfileDir(uuid)
+        val customFile = profileDir.resolve("custom-template.yaml")
+        if (!customFile.exists()) {
+            val fallback = assets.open("templates/default.yaml").use { it.bufferedReader().readText() }
+            customFile.writeText(fallback)
+        }
+
+        val edited = suspendCancellableCoroutine<String?> { cont ->
+            val binding = DialogTextFieldBinding.inflate(layoutInflater, findViewById(android.R.id.content), false)
+            binding.textLayout.hint = "YAML"
+            binding.textField.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            binding.textField.minLines = 12
+            binding.textField.maxLines = 20
+            binding.textField.setText(customFile.readText())
+            binding.textField.setSelection(0)
+
+            val dialog = MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.edit_custom_template)
+                .setView(binding.root)
+                .setPositiveButton(R.string.ok) { _, _ ->
+                    cont.resume(binding.textField.text?.toString())
+                }
+                .setNegativeButton(R.string.cancel) { _, _ ->
+                    cont.resume(null)
+                }
+                .setOnCancelListener {
+                    if (!cont.isCompleted) cont.resume(null)
+                }
+                .create()
+
+            cont.invokeOnCancellation { dialog.dismiss() }
+            dialog.show()
+        } ?: return
+
+        TemplatesBridge.validateTemplateYAML(edited)
+        customFile.writeText(edited)
+        showToast(R.string.custom_template_saved, ToastDuration.Short)
+    }
+
+    private suspend fun ensureWritableProfileDir(uuid: UUID) = withProfile {
+        val profile = queryByUUID(uuid) ?: throw IllegalStateException("Profile not found")
+        patch(profile.uuid, profile.name, profile.source, profile.interval)
+        pendingDir.resolve(uuid.toString())
+    }
+
+    private suspend fun writeTemplateId(uuid: UUID, templateId: String) {
+        val profileDir = ensureWritableProfileDir(uuid)
+        profileDir.resolve("template.txt").writeText(templateId)
+    }
+
+    private fun readCurrentTemplateId(uuid: UUID): String {
+        val pendingFile = pendingDir.resolve(uuid.toString()).resolve("template.txt")
+        if (pendingFile.exists()) return pendingFile.readText().trim()
+
+        val importedFile = importedDir.resolve(uuid.toString()).resolve("template.txt")
+        if (importedFile.exists()) return importedFile.readText().trim()
+
+        return "default"
+    }
+
+    private fun getTemplateDisplayName(templateId: String): String {
+        return when (templateId) {
+            "rubundle" -> getString(R.string.template_rubundle)
+            "davoyan" -> getString(R.string.template_davoyan)
+            "custom" -> getString(R.string.template_custom)
+            else -> getString(R.string.template_default)
         }
     }
 }

--- a/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
@@ -10,6 +10,7 @@ import com.github.kr328.clash.design.R
 import com.github.kr328.clash.design.databinding.DialogTextFieldBinding
 import com.github.kr328.clash.design.ui.ToastDuration
 import com.github.kr328.clash.design.util.showExceptionToast
+import com.github.kr328.clash.design.util.showToast
 import com.github.kr328.clash.service.model.Profile
 import com.github.kr328.clash.service.util.importedDir
 import com.github.kr328.clash.service.util.pendingDir
@@ -146,7 +147,7 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
     private suspend fun selectTemplate(uuid: UUID, design: PropertiesDesign) {
         val templates = TemplatesBridge.getAvailableTemplates()
         if (templates.isEmpty()) {
-            showToast(R.string.error, ToastDuration.Long)
+            design.showToast(R.string.error, ToastDuration.Long)
             return
         }
 
@@ -177,7 +178,7 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
 
         writeTemplateId(uuid, selected)
         design.selectedTemplateName = getTemplateDisplayName(selected)
-        showToast(R.string.template_saved, ToastDuration.Short)
+        design.showToast(R.string.template_saved, ToastDuration.Short)
     }
 
     private suspend fun editCustomTemplate(uuid: UUID) {
@@ -217,7 +218,7 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
 
         TemplatesBridge.validateTemplateYAML(edited)
         customFile.writeText(edited)
-        showToast(R.string.custom_template_saved, ToastDuration.Short)
+        design?.showToast(R.string.custom_template_saved, ToastDuration.Short)
     }
 
     private suspend fun ensureWritableProfileDir(uuid: UUID) = withProfile {

--- a/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
@@ -10,7 +10,6 @@ import com.github.kr328.clash.design.R
 import com.github.kr328.clash.design.databinding.DialogTextFieldBinding
 import com.github.kr328.clash.design.ui.ToastDuration
 import com.github.kr328.clash.design.util.showExceptionToast
-import com.github.kr328.clash.design.util.showToast
 import com.github.kr328.clash.service.model.Profile
 import com.github.kr328.clash.service.util.importedDir
 import com.github.kr328.clash.service.util.pendingDir
@@ -106,11 +105,11 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
     private suspend fun PropertiesDesign.verifyAndCommit() {
         when {
             profile.name.isBlank() -> {
-                showToast(R.string.empty_name, ToastDuration.Long)
+                this@PropertiesActivity.design?.showToast(R.string.empty_name, ToastDuration.Long)
             }
 
             profile.type != Profile.Type.File && profile.source.isBlank() -> {
-                showToast(R.string.invalid_url, ToastDuration.Long)
+                this@PropertiesActivity.design?.showToast(R.string.invalid_url, ToastDuration.Long)
             }
 
             else -> {

--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -522,8 +522,46 @@ JNI_OnLoad(JavaVM *vm, void *reserved) {
 JNIEXPORT jstring JNICALL
 Java_com_github_kr328_clash_core_bridge_Bridge_nativeCoreVersion(JNIEnv *env, jobject thiz) {
     TRACE_METHOD();
-    
+
     char* Version = make_String(GIT_VERSION);
 
     return new_string(Version);
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeDetectProfileFormat(JNIEnv *env, jobject thiz,
+                                                                         jstring content) {
+    TRACE_METHOD();
+
+    scoped_string _content = get_string(content);
+
+    scoped_string format = detectProfileFormat(_content);
+
+    return new_string(format);
+}
+
+JNIEXPORT void JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeConvertProfileToClash(JNIEnv *env, jobject thiz,
+                                                                           jobject completable,
+                                                                           jstring content,
+                                                                           jstring source_format) {
+    TRACE_METHOD();
+
+    jobject _completable = new_global(completable);
+    scoped_string _content = get_string(content);
+    scoped_string _source_format = get_string(source_format);
+
+    convertProfileToClash(_completable, _content, _source_format);
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeValidateClashProfile(JNIEnv *env, jobject thiz,
+                                                                          jstring content) {
+    TRACE_METHOD();
+
+    scoped_string _content = get_string(content);
+
+    scoped_string result = validateClashProfile(_content);
+
+    return new_string(result);
 }

--- a/core/src/main/golang/native/bridge.h
+++ b/core/src/main/golang/native/bridge.h
@@ -51,3 +51,10 @@ extern void log_warn(char *msg);
 extern void log_debug(char *msg);
 
 extern void log_verbose(char *msg);
+
+// Profile conversion functions
+extern char *detectProfileFormat(c_string content);
+
+extern void convertProfileToClash(void *completable, c_string content, c_string source_format);
+
+extern char *validateClashProfile(c_string content);

--- a/core/src/main/golang/native/config/convert.go
+++ b/core/src/main/golang/native/config/convert.go
@@ -1,0 +1,482 @@
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/metacubex/mihomo/common/yaml"
+	"github.com/metacubex/mihomo/config"
+	"github.com/metacubex/mihomo/log"
+)
+
+// ConvertResult represents the result of a profile conversion
+type ConvertResult struct {
+	Success bool   `json:"success"`
+	Content string `json:"content,omitempty"`
+	Format  string `json:"format,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// ProfileFormat represents supported profile formats
+type ProfileFormat string
+
+const (
+	FormatClash        ProfileFormat = "clash"
+	FormatClashMeta    ProfileFormat = "clash_meta"
+	FormatBase64       ProfileFormat = "base64"
+	FormatShadowrocket ProfileFormat = "shadowrocket"
+	FormatV2Ray        ProfileFormat = "v2ray"
+	FormatSIP008       ProfileFormat = "sip008"
+	FormatUnknown      ProfileFormat = "unknown"
+)
+
+// DetectFormat attempts to detect the format of a profile content
+func DetectFormat(content string) ProfileFormat {
+	content = strings.TrimSpace(content)
+
+	// Try to detect YAML (Clash/ClashMeta)
+	if strings.HasPrefix(content, "port:") ||
+		strings.HasPrefix(content, "socks-port:") ||
+		strings.HasPrefix(content, "mixed-port:") ||
+		strings.Contains(content, "\nproxies:") ||
+		strings.Contains(content, "\nproxy-groups:") {
+		return FormatClash
+	}
+
+	// Try to detect Base64 encoded content
+	if isBase64(content) {
+		decoded, err := base64.StdEncoding.DecodeString(content)
+		if err == nil {
+			decodedStr := string(decoded)
+			// Check if decoded content is a proxy URI list
+			if strings.Contains(decodedStr, "://") {
+				return FormatBase64
+			}
+		}
+	}
+
+	// Try to detect SIP008 (Shadowsocks JSON format)
+	if strings.HasPrefix(content, "{") && strings.Contains(content, "servers") {
+		var data map[string]interface{}
+		if err := json.Unmarshal([]byte(content), &data); err == nil {
+			if _, ok := data["servers"]; ok {
+				return FormatSIP008
+			}
+		}
+	}
+
+	// Try to detect proxy URI format (ss://, vmess://, trojan://, etc.)
+	if strings.Contains(content, "ss://") ||
+		strings.Contains(content, "vmess://") ||
+		strings.Contains(content, "trojan://") ||
+		strings.Contains(content, "vless://") {
+		return FormatBase64
+	}
+
+	return FormatUnknown
+}
+
+// isBase64 checks if a string is valid base64
+func isBase64(s string) bool {
+	// Remove common whitespace and newlines
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, " ", "")
+
+	if len(s) == 0 {
+		return false
+	}
+
+	_, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		// Try URL encoding
+		_, err = base64.URLEncoding.DecodeString(s)
+	}
+	return err == nil
+}
+
+// ConvertToClash converts various profile formats to Clash format
+func ConvertToClash(content string, sourceFormat ProfileFormat) (*ConvertResult, error) {
+	result := &ConvertResult{Success: false}
+
+	// Auto-detect if format is unknown
+	if sourceFormat == FormatUnknown {
+		sourceFormat = DetectFormat(content)
+		if sourceFormat == FormatUnknown {
+			result.Error = "unable to detect profile format"
+			return result, fmt.Errorf(result.Error)
+		}
+	}
+
+	result.Format = string(sourceFormat)
+
+	switch sourceFormat {
+	case FormatClash, FormatClashMeta:
+		// Already in Clash format, validate it
+		return validateClashConfig(content)
+
+	case FormatBase64:
+		return convertBase64ToClash(content)
+
+	case FormatSIP008:
+		return convertSIP008ToClash(content)
+
+	default:
+		result.Error = fmt.Sprintf("unsupported source format: %s", sourceFormat)
+		return result, fmt.Errorf(result.Error)
+	}
+}
+
+// validateClashConfig validates a Clash configuration
+func validateClashConfig(content string) (*ConvertResult, error) {
+	result := &ConvertResult{Success: false, Format: string(FormatClash)}
+
+	// Try to parse as YAML
+	_, err := config.UnmarshalRawConfig([]byte(content))
+	if err != nil {
+		result.Error = fmt.Sprintf("invalid clash config: %s", err.Error())
+		return result, err
+	}
+
+	result.Success = true
+	result.Content = content
+	return result, nil
+}
+
+// convertBase64ToClash converts base64 encoded proxy list to Clash format
+func convertBase64ToClash(content string) (*ConvertResult, error) {
+	result := &ConvertResult{Success: false, Format: string(FormatBase64)}
+
+	// Decode base64
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(content))
+	if err != nil {
+		// Try URL encoding
+		decoded, err = base64.URLEncoding.DecodeString(strings.TrimSpace(content))
+		if err != nil {
+			result.Error = fmt.Sprintf("failed to decode base64: %s", err.Error())
+			return result, err
+		}
+	}
+
+	lines := strings.Split(string(decoded), "\n")
+	proxies := make([]map[string]interface{}, 0)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		proxy, err := parseProxyURI(line)
+		if err != nil {
+			log.Warnln("Failed to parse proxy URI: %s, error: %s", line, err.Error())
+			continue
+		}
+
+		if proxy != nil {
+			proxies = append(proxies, proxy)
+		}
+	}
+
+	if len(proxies) == 0 {
+		result.Error = "no valid proxies found in base64 content"
+		return result, fmt.Errorf(result.Error)
+	}
+
+	// Build Clash config
+	clashConfig := map[string]interface{}{
+		"port":       7890,
+		"socks-port": 7891,
+		"allow-lan":  false,
+		"mode":       "rule",
+		"log-level":  "info",
+		"proxies":    proxies,
+		"proxy-groups": []map[string]interface{}{
+			{
+				"name":    "Proxy",
+				"type":    "select",
+				"proxies": getProxyNames(proxies),
+			},
+		},
+		"rules": []string{
+			"MATCH,Proxy",
+		},
+	}
+
+	yamlBytes, err := yaml.Marshal(clashConfig)
+	if err != nil {
+		result.Error = fmt.Sprintf("failed to marshal config: %s", err.Error())
+		return result, err
+	}
+
+	result.Success = true
+	result.Content = string(yamlBytes)
+	return result, nil
+}
+
+// parseProxyURI parses various proxy URI formats (ss://, vmess://, trojan://, etc.)
+func parseProxyURI(uri string) (map[string]interface{}, error) {
+	if strings.HasPrefix(uri, "ss://") {
+		return parseShadowsocksURI(uri)
+	} else if strings.HasPrefix(uri, "vmess://") {
+		return parseVMessURI(uri)
+	} else if strings.HasPrefix(uri, "trojan://") {
+		return parseTrojanURI(uri)
+	}
+
+	return nil, fmt.Errorf("unsupported proxy protocol")
+}
+
+// parseShadowsocksURI parses Shadowsocks URI
+func parseShadowsocksURI(uri string) (map[string]interface{}, error) {
+	// Remove ss:// prefix
+	uri = strings.TrimPrefix(uri, "ss://")
+
+	// Try SIP002 format first: ss://base64(method:password)@server:port#name
+	parts := strings.SplitN(uri, "@", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid shadowsocks URI format")
+	}
+
+	// Decode method:password
+	decoded, err := base64.URLEncoding.DecodeString(parts[0])
+	if err != nil {
+		decoded, err = base64.StdEncoding.DecodeString(parts[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode credentials")
+		}
+	}
+
+	methodPassword := strings.SplitN(string(decoded), ":", 2)
+	if len(methodPassword) != 2 {
+		return nil, fmt.Errorf("invalid method:password format")
+	}
+
+	// Parse server:port and name
+	serverPart := parts[1]
+	name := ""
+	if idx := strings.Index(serverPart, "#"); idx != -1 {
+		name, _ = url.QueryUnescape(serverPart[idx+1:])
+		serverPart = serverPart[:idx]
+	}
+
+	serverPort := strings.SplitN(serverPart, ":", 2)
+	if len(serverPort) != 2 {
+		return nil, fmt.Errorf("invalid server:port format")
+	}
+
+	if name == "" {
+		name = serverPort[0]
+	}
+
+	return map[string]interface{}{
+		"name":     name,
+		"type":     "ss",
+		"server":   serverPort[0],
+		"port":     serverPort[1],
+		"cipher":   methodPassword[0],
+		"password": methodPassword[1],
+		"udp":      true,
+	}, nil
+}
+
+// parseVMessURI parses VMess URI
+func parseVMessURI(uri string) (map[string]interface{}, error) {
+	// VMess URI format: vmess://base64(json)
+	encoded := strings.TrimPrefix(uri, "vmess://")
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		decoded, err = base64.URLEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode vmess URI")
+		}
+	}
+
+	var vmessData map[string]interface{}
+	if err := json.Unmarshal(decoded, &vmessData); err != nil {
+		return nil, fmt.Errorf("failed to parse vmess JSON: %s", err.Error())
+	}
+
+	// Convert to Clash format
+	proxy := map[string]interface{}{
+		"name":   getStringField(vmessData, "ps", "VMess"),
+		"type":   "vmess",
+		"server": getStringField(vmessData, "add", ""),
+		"port":   getIntField(vmessData, "port", 0),
+		"uuid":   getStringField(vmessData, "id", ""),
+		"alterId": getIntField(vmessData, "aid", 0),
+		"cipher": getStringField(vmessData, "scy", "auto"),
+		"udp":    true,
+	}
+
+	// Optional fields
+	if net := getStringField(vmessData, "net", ""); net != "" {
+		proxy["network"] = net
+	}
+
+	if tls := getStringField(vmessData, "tls", ""); tls == "tls" {
+		proxy["tls"] = true
+		if sni := getStringField(vmessData, "sni", ""); sni != "" {
+			proxy["servername"] = sni
+		}
+	}
+
+	return proxy, nil
+}
+
+// parseTrojanURI parses Trojan URI
+func parseTrojanURI(uri string) (map[string]interface{}, error) {
+	// Trojan URI format: trojan://password@server:port#name
+	uri = strings.TrimPrefix(uri, "trojan://")
+
+	parts := strings.SplitN(uri, "@", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid trojan URI format")
+	}
+
+	password := parts[0]
+	serverPart := parts[1]
+
+	name := ""
+	if idx := strings.Index(serverPart, "#"); idx != -1 {
+		name, _ = url.QueryUnescape(serverPart[idx+1:])
+		serverPart = serverPart[:idx]
+	}
+
+	serverPort := strings.SplitN(serverPart, ":", 2)
+	if len(serverPort) != 2 {
+		return nil, fmt.Errorf("invalid server:port format")
+	}
+
+	if name == "" {
+		name = serverPort[0]
+	}
+
+	return map[string]interface{}{
+		"name":     name,
+		"type":     "trojan",
+		"server":   serverPort[0],
+		"port":     serverPort[1],
+		"password": password,
+		"udp":      true,
+		"sni":      serverPort[0],
+	}, nil
+}
+
+// convertSIP008ToClash converts SIP008 (Shadowsocks JSON) to Clash format
+func convertSIP008ToClash(content string) (*ConvertResult, error) {
+	result := &ConvertResult{Success: false, Format: string(FormatSIP008)}
+
+	var sip008 struct {
+		Version int `json:"version"`
+		Servers []struct {
+			Server     string `json:"server"`
+			ServerPort int    `json:"server_port"`
+			Password   string `json:"password"`
+			Method     string `json:"method"`
+			Remarks    string `json:"remarks"`
+		} `json:"servers"`
+	}
+
+	if err := json.Unmarshal([]byte(content), &sip008); err != nil {
+		result.Error = fmt.Sprintf("failed to parse SIP008 JSON: %s", err.Error())
+		return result, err
+	}
+
+	proxies := make([]map[string]interface{}, 0)
+	for _, server := range sip008.Servers {
+		name := server.Remarks
+		if name == "" {
+			name = server.Server
+		}
+
+		proxy := map[string]interface{}{
+			"name":     name,
+			"type":     "ss",
+			"server":   server.Server,
+			"port":     server.ServerPort,
+			"cipher":   server.Method,
+			"password": server.Password,
+			"udp":      true,
+		}
+		proxies = append(proxies, proxy)
+	}
+
+	if len(proxies) == 0 {
+		result.Error = "no valid servers found in SIP008 config"
+		return result, fmt.Errorf(result.Error)
+	}
+
+	// Build Clash config
+	clashConfig := map[string]interface{}{
+		"port":       7890,
+		"socks-port": 7891,
+		"allow-lan":  false,
+		"mode":       "rule",
+		"log-level":  "info",
+		"proxies":    proxies,
+		"proxy-groups": []map[string]interface{}{
+			{
+				"name":    "Proxy",
+				"type":    "select",
+				"proxies": getProxyNames(proxies),
+			},
+		},
+		"rules": []string{
+			"MATCH,Proxy",
+		},
+	}
+
+	yamlBytes, err := yaml.Marshal(clashConfig)
+	if err != nil {
+		result.Error = fmt.Sprintf("failed to marshal config: %s", err.Error())
+		return result, err
+	}
+
+	result.Success = true
+	result.Content = string(yamlBytes)
+	return result, nil
+}
+
+// Helper functions
+
+func getProxyNames(proxies []map[string]interface{}) []string {
+	names := make([]string, 0, len(proxies))
+	for _, proxy := range proxies {
+		if name, ok := proxy["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func getStringField(data map[string]interface{}, key, defaultValue string) string {
+	if val, ok := data[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return defaultValue
+}
+
+func getIntField(data map[string]interface{}, key string, defaultValue int) int {
+	if val, ok := data[key]; ok {
+		switch v := val.(type) {
+		case int:
+			return v
+		case float64:
+			return int(v)
+		case string:
+			// Try to parse string as int
+			var i int
+			if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+				return i
+			}
+		}
+	}
+	return defaultValue
+}

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -103,6 +103,31 @@ func FetchAndValid(
 		if err := fetch(url, configPath); err != nil {
 			return err
 		}
+
+		// After fetching, apply template if needed (for non-YAML profiles)
+		// This converts URI/subscription profiles to full YAML using template
+		templateID, _ := GetCurrentTemplate(path)
+		templateContent, err := GetTemplateContent(templateID, path)
+		if err != nil {
+			// If template loading fails, use default template
+			templateContent, _ = GetBuiltinTemplateContent(TemplateDefault)
+		}
+
+		applied, err := ApplyTemplateIfNeeded(path, templateContent)
+		if err != nil {
+			return fmt.Errorf("failed to apply template: %w", err)
+		}
+
+		if applied {
+			// Report template application status
+			bytes, _ := json.Marshal(&Status{
+				Action:      "ApplyingTemplate",
+				Args:        []string{string(templateID)},
+				Progress:    -1,
+				MaxProgress: -1,
+			})
+			reportStatus(string(bytes))
+		}
 	}
 
 	defer runtime.GC()

--- a/core/src/main/golang/native/config/template.go
+++ b/core/src/main/golang/native/config/template.go
@@ -212,16 +212,18 @@ func ApplyTemplateIfNeeded(profilePath string, templateContent string) (bool, er
 	// For URI or Base64 subscriptions, we need to parse proxies first
 	var proxies []map[string]interface{}
 
-	switch format {
-	case FormatSingleVLESS, FormatSingleTrojan, FormatSingleSS, FormatSingleVMess:
-		// Single URI - parse it
+	// Check if it's a single URI line (starts with protocol)
+	if strings.HasPrefix(contentStr, "ss://") ||
+		strings.HasPrefix(contentStr, "vmess://") ||
+		strings.HasPrefix(contentStr, "trojan://") ||
+		strings.HasPrefix(contentStr, "vless://") {
+		// Single URI - parse it using existing function from convert.go
 		proxy, err := parseProxyURI(contentStr)
 		if err != nil {
 			return false, fmt.Errorf("failed to parse proxy URI: %w", err)
 		}
 		proxies = []map[string]interface{}{proxy}
-
-	case FormatBase64:
+	} else if format == FormatBase64 {
 		// Base64 subscription - decode and parse
 		decoded, err := base64.StdEncoding.DecodeString(contentStr)
 		if err != nil {
@@ -247,8 +249,7 @@ func ApplyTemplateIfNeeded(profilePath string, templateContent string) (bool, er
 		if len(proxies) == 0 {
 			return false, fmt.Errorf("no valid proxies found in subscription")
 		}
-
-	default:
+	} else {
 		// Unknown format - don't apply template
 		log.Warnln("[Template] Unknown format %s, skipping template application", format)
 		return false, nil
@@ -261,20 +262,4 @@ func ApplyTemplateIfNeeded(profilePath string, templateContent string) (bool, er
 
 	log.Infoln("[Template] Applied template to profile with %d proxies", len(proxies))
 	return true, nil
-}
-
-// parseProxyURI parses a single proxy URI (vless://, trojan://, ss://, vmess://)
-func parseProxyURI(uri string) (map[string]interface{}, error) {
-	// Use existing parseVLESS, parseTrojan, etc. from convert.go
-	if strings.HasPrefix(uri, "vless://") {
-		return parseVLESS(uri)
-	} else if strings.HasPrefix(uri, "trojan://") {
-		return parseTrojan(uri)
-	} else if strings.HasPrefix(uri, "ss://") {
-		return parseShadowsocks(uri)
-	} else if strings.HasPrefix(uri, "vmess://") {
-		return parseVMess(uri)
-	}
-
-	return nil, fmt.Errorf("unsupported proxy protocol: %s", uri)
 }

--- a/core/src/main/golang/native/config/template.go
+++ b/core/src/main/golang/native/config/template.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	P "path"
@@ -58,22 +59,22 @@ func GetAvailableTemplates() []Template {
 	}
 }
 
-// GetTemplateContent loads template content from assets or custom file
+// GetTemplateContent loads template content from embedded constants or custom file
 func GetTemplateContent(templateID TemplateID, profilePath string) (string, error) {
 	if templateID == TemplateCustom {
 		// Load custom template from profile directory
 		customPath := P.Join(profilePath, "custom-template.yaml")
 		data, err := os.ReadFile(customPath)
 		if err != nil {
-			return "", fmt.Errorf("failed to read custom template: %w", err)
+			// If custom template doesn't exist, use default as fallback
+			log.Warnln("[Template] Custom template not found, using default")
+			return GetBuiltinTemplateContent(TemplateDefault)
 		}
 		return string(data), nil
 	}
 
-	// Load builtin template from assets
-	// Note: In actual implementation, this will load from Android assets
-	// For now, return empty string - will be implemented in Android layer
-	return "", fmt.Errorf("builtin templates are loaded from Android assets")
+	// Load builtin template from embedded constants
+	return GetBuiltinTemplateContent(templateID)
 }
 
 // GetCurrentTemplate returns the template ID used by a profile
@@ -184,4 +185,96 @@ func ValidateTemplateYAML(content string) error {
 	}
 
 	return nil
+}
+
+// ApplyTemplateIfNeeded checks if config is non-YAML (URI/subscription) and applies template
+// Returns true if template was applied, false if it's already a valid YAML config
+func ApplyTemplateIfNeeded(profilePath string, templateContent string) (bool, error) {
+	configPath := P.Join(profilePath, "config.yaml")
+
+	// Read current config.yaml content
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	contentStr := string(configData)
+
+	// Try to detect format
+	format := DetectFormat(contentStr)
+
+	// If it's already Clash/ClashMeta YAML, don't apply template
+	if format == FormatClash || format == FormatClashMeta {
+		log.Infoln("[Template] Config is already YAML, skipping template application")
+		return false, nil
+	}
+
+	// For URI or Base64 subscriptions, we need to parse proxies first
+	var proxies []map[string]interface{}
+
+	switch format {
+	case FormatSingleVLESS, FormatSingleTrojan, FormatSingleSS, FormatSingleVMess:
+		// Single URI - parse it
+		proxy, err := parseProxyURI(contentStr)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse proxy URI: %w", err)
+		}
+		proxies = []map[string]interface{}{proxy}
+
+	case FormatBase64:
+		// Base64 subscription - decode and parse
+		decoded, err := base64.StdEncoding.DecodeString(contentStr)
+		if err != nil {
+			return false, fmt.Errorf("failed to decode base64: %w", err)
+		}
+
+		// Parse each line as proxy URI
+		lines := strings.Split(string(decoded), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+
+			proxy, err := parseProxyURI(line)
+			if err != nil {
+				log.Warnln("[Template] Failed to parse proxy line: %s, error: %s", line, err)
+				continue // Skip invalid proxies
+			}
+			proxies = append(proxies, proxy)
+		}
+
+		if len(proxies) == 0 {
+			return false, fmt.Errorf("no valid proxies found in subscription")
+		}
+
+	default:
+		// Unknown format - don't apply template
+		log.Warnln("[Template] Unknown format %s, skipping template application", format)
+		return false, nil
+	}
+
+	// Apply template with parsed proxies
+	if err := ApplyTemplateToProfile(profilePath, templateContent, proxies); err != nil {
+		return false, fmt.Errorf("failed to apply template: %w", err)
+	}
+
+	log.Infoln("[Template] Applied template to profile with %d proxies", len(proxies))
+	return true, nil
+}
+
+// parseProxyURI parses a single proxy URI (vless://, trojan://, ss://, vmess://)
+func parseProxyURI(uri string) (map[string]interface{}, error) {
+	// Use existing parseVLESS, parseTrojan, etc. from convert.go
+	if strings.HasPrefix(uri, "vless://") {
+		return parseVLESS(uri)
+	} else if strings.HasPrefix(uri, "trojan://") {
+		return parseTrojan(uri)
+	} else if strings.HasPrefix(uri, "ss://") {
+		return parseShadowsocks(uri)
+	} else if strings.HasPrefix(uri, "vmess://") {
+		return parseVMess(uri)
+	}
+
+	return nil, fmt.Errorf("unsupported proxy protocol: %s", uri)
 }

--- a/core/src/main/golang/native/config/template.go
+++ b/core/src/main/golang/native/config/template.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	P "path"
+	"strings"
+
+	"github.com/metacubex/mihomo/common/yaml"
+	"github.com/metacubex/mihomo/log"
+)
+
+// TemplateID represents available template types
+type TemplateID string
+
+const (
+	TemplateDefault  TemplateID = "default"
+	TemplateRubundle TemplateID = "rubundle"
+	TemplateDavoyan  TemplateID = "davoyan"
+	TemplateCustom   TemplateID = "custom"
+)
+
+// Template represents a profile template
+type Template struct {
+	ID          TemplateID `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Builtin     bool       `json:"builtin"` // true for default/rubundle/davoyan, false for custom
+}
+
+// GetAvailableTemplates returns list of available templates
+func GetAvailableTemplates() []Template {
+	return []Template{
+		{
+			ID:          TemplateDefault,
+			Name:        "Default",
+			Description: "Базовый шаблон с фокусом на российские сервисы",
+			Builtin:     true,
+		},
+		{
+			ID:          TemplateRubundle,
+			Name:        "RU Bundle",
+			Description: "Шаблон с Re:filter и международными сервисами",
+			Builtin:     true,
+		},
+		{
+			ID:          TemplateDavoyan,
+			Name:        "Davoyan",
+			Description: "Детальная настройка роутинга для российских пользователей",
+			Builtin:     true,
+		},
+		{
+			ID:          TemplateCustom,
+			Name:        "Custom",
+			Description: "Пользовательский редактируемый шаблон",
+			Builtin:     false,
+		},
+	}
+}
+
+// GetTemplateContent loads template content from assets or custom file
+func GetTemplateContent(templateID TemplateID, profilePath string) (string, error) {
+	if templateID == TemplateCustom {
+		// Load custom template from profile directory
+		customPath := P.Join(profilePath, "custom-template.yaml")
+		data, err := os.ReadFile(customPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read custom template: %w", err)
+		}
+		return string(data), nil
+	}
+
+	// Load builtin template from assets
+	// Note: In actual implementation, this will load from Android assets
+	// For now, return empty string - will be implemented in Android layer
+	return "", fmt.Errorf("builtin templates are loaded from Android assets")
+}
+
+// GetCurrentTemplate returns the template ID used by a profile
+func GetCurrentTemplate(profilePath string) (TemplateID, error) {
+	templateFile := P.Join(profilePath, "template.txt")
+	data, err := os.ReadFile(templateFile)
+	if err != nil {
+		// Default to "default" template if file doesn't exist
+		return TemplateDefault, nil
+	}
+
+	templateID := TemplateID(strings.TrimSpace(string(data)))
+
+	// Validate template ID
+	validTemplates := map[TemplateID]bool{
+		TemplateDefault:  true,
+		TemplateRubundle: true,
+		TemplateDavoyan:  true,
+		TemplateCustom:   true,
+	}
+
+	if !validTemplates[templateID] {
+		log.Warnln("Invalid template ID '%s' in profile, using default", templateID)
+		return TemplateDefault, nil
+	}
+
+	return templateID, nil
+}
+
+// SetCurrentTemplate saves the template ID for a profile
+func SetCurrentTemplate(profilePath string, templateID TemplateID) error {
+	templateFile := P.Join(profilePath, "template.txt")
+	return os.WriteFile(templateFile, []byte(string(templateID)), 0644)
+}
+
+// ApplyTemplateToProfile merges proxies from subscription with template
+func ApplyTemplateToProfile(profilePath string, templateContent string, proxies []map[string]interface{}) error {
+	// Parse template YAML
+	var templateConfig map[string]interface{}
+	if err := yaml.Unmarshal([]byte(templateContent), &templateConfig); err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	// Merge proxies from subscription into template
+	templateConfig["proxies"] = proxies
+
+	// Update proxy groups with include-all
+	if proxyGroups, ok := templateConfig["proxy-groups"].([]interface{}); ok {
+		for _, group := range proxyGroups {
+			if groupMap, ok := group.(map[string]interface{}); ok {
+				// If group has include-all: true, add all proxy names
+				if includeAll, ok := groupMap["include-all"].(bool); ok && includeAll {
+					proxyNames := make([]string, 0, len(proxies))
+					for _, proxy := range proxies {
+						if name, ok := proxy["name"].(string); ok {
+							proxyNames = append(proxyNames, name)
+						}
+					}
+
+					// Append to existing proxies list
+					if existingProxies, ok := groupMap["proxies"].([]interface{}); ok {
+						for _, proxyName := range proxyNames {
+							existingProxies = append(existingProxies, proxyName)
+						}
+						groupMap["proxies"] = existingProxies
+					} else {
+						// Create new proxies list
+						proxiesInterface := make([]interface{}, len(proxyNames))
+						for i, name := range proxyNames {
+							proxiesInterface[i] = name
+						}
+						groupMap["proxies"] = proxiesInterface
+					}
+				}
+			}
+		}
+	}
+
+	// Marshal back to YAML
+	yamlData, err := yaml.Marshal(templateConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	// Write to config.yaml
+	configPath := P.Join(profilePath, "config.yaml")
+	if err := os.WriteFile(configPath, yamlData, 0644); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	log.Infoln("Applied template to profile at %s", profilePath)
+	return nil
+}
+
+// ValidateTemplateYAML validates that template YAML is parseable
+func ValidateTemplateYAML(content string) error {
+	var config map[string]interface{}
+	if err := yaml.Unmarshal([]byte(content), &config); err != nil {
+		return fmt.Errorf("invalid YAML: %w", err)
+	}
+
+	// Basic validation - check required fields
+	requiredFields := []string{"mode", "proxies", "proxy-groups", "rules"}
+	for _, field := range requiredFields {
+		if _, ok := config[field]; !ok {
+			return fmt.Errorf("missing required field: %s", field)
+		}
+	}
+
+	return nil
+}

--- a/core/src/main/golang/native/config/templates_embedded.go
+++ b/core/src/main/golang/native/config/templates_embedded.go
@@ -142,17 +142,354 @@ rules:
   - MATCH,PROXY
 `
 
+const TemplateRubundleContent = `# RU Bundle Template for ClashMetaForAndroid
+mode: rule
+log-level: info
+mixed-port: 7890
+unified-delay: true
+allow-lan: true
+tcp-concurrent: true
+enable-process: true
+find-process-mode: always
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  sniff:
+    HTTP:
+      ports:
+        - 80
+        - 8080-8880
+      override-destination: true
+    TLS:
+      ports:
+        - 443
+        - 8443
+
+dns:
+  enable: true
+  prefer-h3: true
+  use-hosts: true
+  use-system-hosts: true
+  ipv6: false
+  enhanced-mode: redir-host
+  default-nameserver:
+    - tls://77.88.8.8#DIRECT
+    - 195.208.4.1#DIRECT
+  nameserver:
+    - https://cloudflare-dns.com/dns-query#PROXY
+
+proxies:
+  # Proxies will be injected here from subscription
+
+proxy-groups:
+  - name: PROXY
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Hijacking.png
+    type: select
+    proxies:
+      - AUTO
+    include-all: true
+
+  - name: YouTube
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/YouTube.png
+    type: select
+    proxies:
+      - PROXY
+    include-all: true
+
+  - name: Discord
+    icon: https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/icons/Discord.png
+    type: select
+    proxies:
+      - PROXY
+    include-all: true
+
+  - name: Telegram
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Telegram.png
+    type: select
+    include-all: true
+    proxies:
+      - PROXY
+
+  - name: AUTO
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Auto.png
+    type: url-test
+    tolerance: 150
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    proxies: []
+    include-all: true
+
+rule-providers:
+  telegram-ips:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    interval: 86400
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/telegram.mrs
+    path: ./rule-sets/telegram-ips.mrs
+
+  telegram-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    interval: 86400
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/telegram.mrs
+    path: ./rule-sets/telegram-domains.mrs
+
+  discord-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/discord.mrs
+    path: ./rule-sets/discord-domains.mrs
+    interval: 86400
+
+  refilter-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/re-filter/domain-rule.mrs
+    path: ./rule-sets/refilter-domains.mrs
+    interval: 86400
+
+  refilter-ips:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/re-filter/ip-rule.mrs
+    path: ./rule-sets/refilter-ips.mrs
+    interval: 86400
+
+  youtube:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/youtube.mrs
+    path: ./rule-sets/youtube.mrs
+    interval: 86400
+
+  ru-bundle:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/ru-bundle/rule.mrs
+    path: ./rule-sets/ru-bundle.mrs
+    interval: 86400
+
+rules:
+  - OR,((RULE-SET,telegram-ips),(RULE-SET,telegram-domains)),Telegram
+  - RULE-SET,youtube,YouTube
+  - RULE-SET,discord-domains,Discord
+  - RULE-SET,ru-bundle,PROXY
+  - RULE-SET,refilter-domains,PROXY
+  - RULE-SET,refilter-ips,PROXY
+  - MATCH,DIRECT
+`
+
+const TemplateDavoyanContent = `# Davoyan Template for ClashMetaForAndroid
+mixed-port: 7890
+allow-lan: true
+tcp-concurrent: true
+enable-process: true
+find-process-mode: always
+mode: rule
+log-level: info
+ipv6: false
+bind-address: "*"
+keep-alive-interval: 30
+unified-delay: false
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  override-destination: false
+  sniff:
+    HTTP:
+      ports:
+        - 80
+        - 8080-8880
+      override-destination: true
+    TLS:
+      ports:
+        - 443
+        - 8443
+
+dns:
+  enable: true
+  prefer-h3: false
+  use-hosts: true
+  use-system-hosts: true
+  ipv6: false
+  enhanced-mode: redir-host
+  default-nameserver:
+    - https://94.140.14.14/dns-query#DIRECT
+    - https://8.8.8.8/dns-query#DIRECT
+  proxy-server-nameserver:
+    - https://94.140.14.14/dns-query#DIRECT
+    - https://8.8.8.8/dns-query#DIRECT
+  direct-nameserver:
+    - 77.88.8.8#DIRECT
+    - 77.88.8.1#DIRECT
+  nameserver:
+    - tls://94.140.14.14#PROXY
+    - tls://94.140.15.15#PROXY
+
+proxies:
+  # Proxies will be injected here from subscription
+
+proxy-groups:
+  - name: Blocked Sites
+    icon: https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/icons/Blocked.png
+    type: select
+    include-all: true
+    proxies:
+      - AUTO
+      - DIRECT
+
+  - name: YouTube
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/YouTube.png
+    type: select
+    include-all: true
+    proxies:
+      - Blocked Sites
+
+  - name: Discord
+    icon: https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/icons/Discord.png
+    type: select
+    include-all: true
+    proxies:
+      - Blocked Sites
+
+  - name: Telegram
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Telegram.png
+    type: select
+    include-all: true
+    proxies:
+      - Blocked Sites
+      - DIRECT
+
+  - name: RU Sites
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Russia.png
+    type: select
+    proxies:
+      - DIRECT
+
+  - name: Other Sites
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Global.png
+    type: select
+    include-all: true
+    proxies:
+      - DIRECT
+      - Blocked Sites
+
+  - name: PROXY
+    type: select
+    hidden: true
+    proxies:
+      - Blocked Sites
+    include-all: true
+
+  - name: AUTO
+    type: url-test
+    hidden: true
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    include-all: true
+
+  - name: DIRECT
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Blackhole.png
+    type: select
+    hidden: true
+    proxies:
+      - DIRECT
+
+rule-providers:
+  geoip-private:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/private.mrs
+    path: ./rule-sets/geoip-private.mrs
+    interval: 86400
+
+  geosite-private:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/private.mrs
+    path: ./rule-sets/geosite-private.mrs
+    interval: 86400
+
+  youtube:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/youtube.mrs
+    path: ./rule-sets/youtube.mrs
+    interval: 86400
+
+  telegram-ips:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/telegram.mrs
+    path: ./rule-sets/telegram-ips.mrs
+    interval: 86400
+
+  telegram-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/telegram.mrs
+    path: ./rule-sets/telegram-domains.mrs
+    interval: 86400
+
+  discord-domains:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/discord.mrs
+    path: ./rule-sets/discord-domains.mrs
+    interval: 86400
+
+  ru-inline:
+    type: http
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/inline/ru-inline.yaml
+    interval: 86400
+    behavior: classical
+    format: yaml
+    path: ./rule-sets/ru-inline.yaml
+
+rules:
+  - RULE-SET,geoip-private,DIRECT,no-resolve
+  - RULE-SET,geosite-private,DIRECT
+  - RULE-SET,youtube,YouTube
+  - OR,((RULE-SET,telegram-ips),(RULE-SET,telegram-domains)),Telegram
+  - RULE-SET,discord-domains,Discord
+  - RULE-SET,ru-inline,RU Sites
+  - MATCH,Other Sites
+`
+
 // GetBuiltinTemplateContent returns embedded template content by ID
 func GetBuiltinTemplateContent(templateID TemplateID) (string, error) {
 	switch templateID {
 	case TemplateDefault:
 		return TemplateDefaultContent, nil
 	case TemplateRubundle:
-		// TODO: Add rubundle template content
-		return TemplateDefaultContent, nil
+		return TemplateRubundleContent, nil
 	case TemplateDavoyan:
-		// TODO: Add davoyan template content
-		return TemplateDefaultContent, nil
+		return TemplateDavoyanContent, nil
 	default:
 		return "", fmt.Errorf("unknown builtin template: %s", templateID)
 	}

--- a/core/src/main/golang/native/config/templates_embedded.go
+++ b/core/src/main/golang/native/config/templates_embedded.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 // Builtin templates embedded in Go code
 // These are synced with app/src/main/assets/templates/*.yaml
 

--- a/core/src/main/golang/native/config/templates_embedded.go
+++ b/core/src/main/golang/native/config/templates_embedded.go
@@ -1,0 +1,157 @@
+package config
+
+// Builtin templates embedded in Go code
+// These are synced with app/src/main/assets/templates/*.yaml
+
+const TemplateDefaultContent = `# Default Template for ClashMetaForAndroid
+mixed-port: 7890
+allow-lan: true
+tcp-concurrent: true
+enable-process: true
+find-process-mode: always
+mode: rule
+log-level: info
+ipv6: false
+keep-alive-interval: 30
+unified-delay: true
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  sniff:
+    HTTP:
+      ports:
+        - 80
+        - 8080-8880
+      override-destination: true
+    TLS:
+      ports:
+        - 443
+        - 8443
+
+dns:
+  enable: true
+  prefer-h3: true
+  use-hosts: true
+  use-system-hosts: true
+  ipv6: false
+  enhanced-mode: redir-host
+  default-nameserver:
+    - tls://77.88.8.8#DIRECT
+    - 195.208.4.1#DIRECT
+  nameserver:
+    - https://cloudflare-dns.com/dns-query#PROXY
+    - https://1.1.1.1/dns-query#PROXY
+
+proxies:
+  # Proxies will be injected here from subscription
+
+proxy-groups:
+  - name: PROXY
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Hijacking.png
+    type: select
+    include-all: true
+    proxies:
+      - AUTO
+
+  - name: AUTO
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Auto.png
+    type: url-test
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    include-all: true
+
+  - name: YouTube
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/YouTube.png
+    type: select
+    include-all: true
+    proxies:
+      - PROXY
+      - AUTO
+
+  - name: DIRECT
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Blackhole.png
+    type: select
+    hidden: true
+    proxies:
+      - DIRECT
+
+rule-providers:
+  ru-inline:
+    type: http
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/inline/ru-inline.yaml
+    interval: 86400
+    behavior: classical
+    format: yaml
+    path: ./rule-sets/ru-inline.yaml
+
+  youtube:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/youtube.mrs
+    path: ./rule-sets/youtube.mrs
+    interval: 86400
+
+  geosite-ru:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/category-ru.mrs
+    path: ./rule-sets/geosite-ru.mrs
+    interval: 86400
+
+  geoip-ru:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/ru.mrs
+    path: ./rule-sets/geoip-ru.mrs
+    interval: 86400
+
+  geosite-private:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/private.mrs
+    path: ./rule-sets/geosite-private.mrs
+    interval: 86400
+
+  geoip-private:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/private.mrs
+    path: ./rule-sets/geoip-private.mrs
+    interval: 86400
+
+rules:
+  - RULE-SET,youtube,YouTube
+  - RULE-SET,geoip-private,DIRECT,no-resolve
+  - RULE-SET,geosite-private,DIRECT
+  - RULE-SET,ru-inline,DIRECT
+  - RULE-SET,geosite-ru,DIRECT
+  - RULE-SET,geoip-ru,DIRECT
+  - MATCH,PROXY
+`
+
+// GetBuiltinTemplateContent returns embedded template content by ID
+func GetBuiltinTemplateContent(templateID TemplateID) (string, error) {
+	switch templateID {
+	case TemplateDefault:
+		return TemplateDefaultContent, nil
+	case TemplateRubundle:
+		// TODO: Add rubundle template content
+		return TemplateDefaultContent, nil
+	case TemplateDavoyan:
+		// TODO: Add davoyan template content
+		return TemplateDefaultContent, nil
+	default:
+		return "", fmt.Errorf("unknown builtin template: %s", templateID)
+	}
+}

--- a/core/src/main/golang/native/convert.go
+++ b/core/src/main/golang/native/convert.go
@@ -1,0 +1,74 @@
+package main
+
+//#include "bridge.h"
+import "C"
+
+import (
+	"encoding/json"
+	"runtime"
+	"unsafe"
+
+	"cfa/native/config"
+)
+
+//export detectProfileFormat
+func detectProfileFormat(content C.c_string) *C.char {
+	contentStr := C.GoString(content)
+	format := config.DetectFormat(contentStr)
+	return C.CString(string(format))
+}
+
+//export convertProfileToClash
+func convertProfileToClash(completable unsafe.Pointer, content C.c_string, sourceFormat C.c_string) {
+	go func(content, format string) {
+		var result *config.ConvertResult
+		var err error
+
+		if format == "" || format == "auto" {
+			// Auto-detect format
+			result, err = config.ConvertToClash(content, config.FormatUnknown)
+		} else {
+			// Use specified format
+			result, err = config.ConvertToClash(content, config.ProfileFormat(format))
+		}
+
+		// Marshal result to JSON
+		var resultJSON string
+		if err != nil && result == nil {
+			// Create error result
+			result = &config.ConvertResult{
+				Success: false,
+				Error:   err.Error(),
+			}
+		}
+
+		jsonBytes, marshalErr := json.Marshal(result)
+		if marshalErr != nil {
+			resultJSON = `{"success":false,"error":"failed to marshal result"}`
+		} else {
+			resultJSON = string(jsonBytes)
+		}
+
+		C.complete(completable, marshalString(resultJSON))
+		C.release_object(completable)
+
+		runtime.GC()
+	}(C.GoString(content), C.GoString(sourceFormat))
+}
+
+//export validateClashProfile
+func validateClashProfile(content C.c_string) *C.char {
+	contentStr := C.GoString(content)
+
+	result, err := config.ConvertToClash(contentStr, config.FormatClash)
+	if err != nil {
+		return C.CString(`{"success":false,"error":"` + err.Error() + `"}`)
+	}
+
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return C.CString(`{"success":false,"error":"failed to marshal result"}`)
+	}
+
+	return C.CString(string(jsonBytes))
+}

--- a/core/src/main/golang/native/template_export.go
+++ b/core/src/main/golang/native/template_export.go
@@ -1,0 +1,83 @@
+package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"cfa/native/config"
+	"encoding/json"
+	"unsafe"
+)
+
+//export GetAvailableTemplates
+func GetAvailableTemplates() *C.char {
+	templates := config.GetAvailableTemplates()
+
+	jsonData, err := json.Marshal(templates)
+	if err != nil {
+		return C.CString(`{"error": "failed to marshal templates"}`)
+	}
+
+	return C.CString(string(jsonData))
+}
+
+//export GetCurrentTemplate
+func GetCurrentTemplate(profilePath *C.char) *C.char {
+	path := C.GoString(profilePath)
+
+	templateID, err := config.GetCurrentTemplate(path)
+	if err != nil {
+		return C.CString(string(config.TemplateDefault))
+	}
+
+	return C.CString(string(templateID))
+}
+
+//export SetCurrentTemplate
+func SetCurrentTemplate(profilePath *C.char, templateID *C.char) *C.char {
+	path := C.GoString(profilePath)
+	id := config.TemplateID(C.GoString(templateID))
+
+	if err := config.SetCurrentTemplate(path, id); err != nil {
+		return C.CString(err.Error())
+	}
+
+	return nil
+}
+
+//export ApplyTemplateToProfile
+func ApplyTemplateToProfile(profilePath *C.char, templateContent *C.char, proxiesJSON *C.char) *C.char {
+	path := C.GoString(profilePath)
+	content := C.GoString(templateContent)
+	proxiesStr := C.GoString(proxiesJSON)
+
+	// Parse proxies JSON
+	var proxies []map[string]interface{}
+	if err := json.Unmarshal([]byte(proxiesStr), &proxies); err != nil {
+		return C.CString("failed to parse proxies JSON: " + err.Error())
+	}
+
+	// Apply template
+	if err := config.ApplyTemplateToProfile(path, content, proxies); err != nil {
+		return C.CString(err.Error())
+	}
+
+	return nil
+}
+
+//export ValidateTemplateYAML
+func ValidateTemplateYAML(content *C.char) *C.char {
+	yamlContent := C.GoString(content)
+
+	if err := config.ValidateTemplateYAML(yamlContent); err != nil {
+		return C.CString(err.Error())
+	}
+
+	return nil
+}
+
+//export FreeString
+func FreeString(str *C.char) {
+	C.free(unsafe.Pointer(str))
+}

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -50,6 +50,15 @@ object Bridge {
     external fun nativeSubscribeLogcat(callback: LogcatInterface)
     external fun nativeCoreVersion(): String
 
+    // Profile conversion functions
+    external fun nativeDetectProfileFormat(content: String): String
+    external fun nativeConvertProfileToClash(
+        completable: CompletableDeferred<String>,
+        content: String,
+        sourceFormat: String
+    )
+    external fun nativeValidateClashProfile(content: String): String
+
     private external fun nativeInit(home: String, versionName: String, sdkVersion: Int)
 
     init {

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/ConvertResult.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/ConvertResult.kt
@@ -1,0 +1,45 @@
+package com.github.kr328.clash.core.bridge
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class ConvertResult(
+    val success: Boolean,
+    val content: String? = null,
+    val format: String? = null,
+    val error: String? = null
+) {
+    companion object {
+        private val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
+
+        fun fromJson(jsonString: String): ConvertResult {
+            return try {
+                json.decodeFromString(jsonString)
+            } catch (e: Exception) {
+                ConvertResult(
+                    success = false,
+                    error = "Failed to parse result: ${e.message}"
+                )
+            }
+        }
+    }
+
+    fun getDetectedFormat(): ProfileFormat {
+        return format?.let { ProfileFormat.fromString(it) } ?: ProfileFormat.UNKNOWN
+    }
+
+    fun isSuccess(): Boolean = success && content != null
+
+    fun getErrorMessage(): String = error ?: "Unknown error"
+
+    fun getClashConfig(): String {
+        if (!isSuccess()) {
+            throw IllegalStateException("Cannot get config from failed conversion: ${getErrorMessage()}")
+        }
+        return content!!
+    }
+}

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/ConvertResult.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/ConvertResult.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash.core.bridge
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.decodeFromString
 
 @Serializable
 data class ConvertResult(
@@ -18,7 +19,7 @@ data class ConvertResult(
 
         fun fromJson(jsonString: String): ConvertResult {
             return try {
-                json.decodeFromString(jsonString)
+                json.decodeFromString<ConvertResult>(jsonString)
             } catch (e: Exception) {
                 ConvertResult(
                     success = false,

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/ProfileConverter.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/ProfileConverter.kt
@@ -1,0 +1,116 @@
+package com.github.kr328.clash.core.bridge
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * High-level API for profile format conversion
+ */
+object ProfileConverter {
+
+    /**
+     * Detect the format of a profile content
+     *
+     * @param content The profile content to detect
+     * @return The detected ProfileFormat
+     */
+    fun detectFormat(content: String): ProfileFormat {
+        val formatString = Bridge.nativeDetectProfileFormat(content)
+        return ProfileFormat.fromString(formatString)
+    }
+
+    /**
+     * Convert a profile to Clash format (async)
+     *
+     * @param content The profile content to convert
+     * @param sourceFormat The source format (use AUTO for auto-detection)
+     * @return ConvertResult containing the converted config or error
+     */
+    suspend fun convertToClash(
+        content: String,
+        sourceFormat: ProfileFormat = ProfileFormat.AUTO
+    ): ConvertResult = withContext(Dispatchers.IO) {
+        val completable = CompletableDeferred<String>()
+
+        Bridge.nativeConvertProfileToClash(
+            completable,
+            content,
+            sourceFormat.value
+        )
+
+        val resultJson = completable.await()
+        ConvertResult.fromJson(resultJson)
+    }
+
+    /**
+     * Convert a profile to Clash format (blocking)
+     *
+     * @param content The profile content to convert
+     * @param sourceFormat The source format (use AUTO for auto-detection)
+     * @return ConvertResult containing the converted config or error
+     */
+    @Deprecated(
+        "Use suspend version instead",
+        ReplaceWith("convertToClash(content, sourceFormat)", "kotlinx.coroutines.runBlocking")
+    )
+    fun convertToClashBlocking(
+        content: String,
+        sourceFormat: ProfileFormat = ProfileFormat.AUTO
+    ): ConvertResult {
+        return kotlinx.coroutines.runBlocking {
+            convertToClash(content, sourceFormat)
+        }
+    }
+
+    /**
+     * Validate a Clash profile
+     *
+     * @param content The Clash profile content to validate
+     * @return ConvertResult indicating validation success or error
+     */
+    fun validate(content: String): ConvertResult {
+        val resultJson = Bridge.nativeValidateClashProfile(content)
+        return ConvertResult.fromJson(resultJson)
+    }
+
+    /**
+     * Check if content is a valid Clash profile
+     *
+     * @param content The content to check
+     * @return true if valid, false otherwise
+     */
+    fun isValidClashProfile(content: String): Boolean {
+        return validate(content).isSuccess()
+    }
+
+    /**
+     * Detect and convert a profile to Clash format in one step
+     *
+     * @param content The profile content
+     * @return ConvertResult with the converted config
+     */
+    suspend fun autoConvert(content: String): ConvertResult {
+        return convertToClash(content, ProfileFormat.AUTO)
+    }
+
+    /**
+     * Convert a Base64 encoded profile to Clash format
+     *
+     * @param base64Content The Base64 encoded content
+     * @return ConvertResult with the converted config
+     */
+    suspend fun convertBase64ToClash(base64Content: String): ConvertResult {
+        return convertToClash(base64Content, ProfileFormat.BASE64)
+    }
+
+    /**
+     * Convert a SIP008 (Shadowsocks JSON) profile to Clash format
+     *
+     * @param sip008Content The SIP008 JSON content
+     * @return ConvertResult with the converted config
+     */
+    suspend fun convertSIP008ToClash(sip008Content: String): ConvertResult {
+        return convertToClash(sip008Content, ProfileFormat.SIP008)
+    }
+}

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/ProfileFormat.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/ProfileFormat.kt
@@ -1,0 +1,20 @@
+package com.github.kr328.clash.core.bridge
+
+enum class ProfileFormat(val value: String) {
+    CLASH("clash"),
+    CLASH_META("clash_meta"),
+    BASE64("base64"),
+    SHADOWROCKET("shadowrocket"),
+    V2RAY("v2ray"),
+    SIP008("sip008"),
+    UNKNOWN("unknown"),
+    AUTO("auto");
+
+    companion object {
+        fun fromString(value: String): ProfileFormat {
+            return values().find { it.value == value } ?: UNKNOWN
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/ProfileUtils.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/ProfileUtils.kt
@@ -1,0 +1,169 @@
+package com.github.kr328.clash.core.bridge
+
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Utility functions for working with profile files and streams
+ */
+object ProfileUtils {
+
+    /**
+     * Read and convert a profile from a file
+     *
+     * @param file The file containing the profile
+     * @param sourceFormat The source format (AUTO for auto-detection)
+     * @return ConvertResult with the converted config
+     */
+    suspend fun convertFileToClash(
+        file: File,
+        sourceFormat: ProfileFormat = ProfileFormat.AUTO
+    ): ConvertResult {
+        if (!file.exists()) {
+            return ConvertResult(
+                success = false,
+                error = "File does not exist: ${file.absolutePath}"
+            )
+        }
+
+        if (!file.canRead()) {
+            return ConvertResult(
+                success = false,
+                error = "Cannot read file: ${file.absolutePath}"
+            )
+        }
+
+        return try {
+            val content = file.readText()
+            ProfileConverter.convertToClash(content, sourceFormat)
+        } catch (e: Exception) {
+            ConvertResult(
+                success = false,
+                error = "Failed to read file: ${e.message}"
+            )
+        }
+    }
+
+    /**
+     * Read and convert a profile from an InputStream
+     *
+     * @param inputStream The input stream containing the profile
+     * @param sourceFormat The source format (AUTO for auto-detection)
+     * @return ConvertResult with the converted config
+     */
+    suspend fun convertStreamToClash(
+        inputStream: InputStream,
+        sourceFormat: ProfileFormat = ProfileFormat.AUTO
+    ): ConvertResult {
+        return try {
+            val content = inputStream.bufferedReader().use { it.readText() }
+            ProfileConverter.convertToClash(content, sourceFormat)
+        } catch (e: Exception) {
+            ConvertResult(
+                success = false,
+                error = "Failed to read stream: ${e.message}"
+            )
+        }
+    }
+
+    /**
+     * Save a ConvertResult to a file
+     *
+     * @param result The conversion result
+     * @param outputFile The output file
+     * @return true if successful, false otherwise
+     */
+    fun saveToFile(result: ConvertResult, outputFile: File): Boolean {
+        if (!result.isSuccess()) {
+            return false
+        }
+
+        return try {
+            outputFile.parentFile?.mkdirs()
+            outputFile.writeText(result.getClashConfig())
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Check if a file contains a valid Clash profile
+     *
+     * @param file The file to check
+     * @return true if valid, false otherwise
+     */
+    fun isValidClashFile(file: File): Boolean {
+        if (!file.exists() || !file.canRead()) {
+            return false
+        }
+
+        return try {
+            val content = file.readText()
+            ProfileConverter.isValidClashProfile(content)
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Detect the format of a profile file
+     *
+     * @param file The file to detect
+     * @return The detected ProfileFormat
+     */
+    fun detectFileFormat(file: File): ProfileFormat {
+        if (!file.exists() || !file.canRead()) {
+            return ProfileFormat.UNKNOWN
+        }
+
+        return try {
+            val content = file.readText()
+            ProfileConverter.detectFormat(content)
+        } catch (e: Exception) {
+            ProfileFormat.UNKNOWN
+        }
+    }
+
+    /**
+     * Get a user-friendly name for a ProfileFormat
+     *
+     * @param format The format
+     * @return Human-readable format name
+     */
+    fun getFormatDisplayName(format: ProfileFormat): String {
+        return when (format) {
+            ProfileFormat.CLASH -> "Clash"
+            ProfileFormat.CLASH_META -> "Clash Meta"
+            ProfileFormat.BASE64 -> "Base64 (Subscription)"
+            ProfileFormat.SHADOWROCKET -> "Shadowrocket"
+            ProfileFormat.V2RAY -> "V2Ray"
+            ProfileFormat.SIP008 -> "SIP008 (Shadowsocks)"
+            ProfileFormat.UNKNOWN -> "Unknown"
+            ProfileFormat.AUTO -> "Auto Detect"
+        }
+    }
+
+    /**
+     * Get supported import formats
+     *
+     * @return List of formats that can be imported
+     */
+    fun getSupportedImportFormats(): List<ProfileFormat> {
+        return listOf(
+            ProfileFormat.CLASH,
+            ProfileFormat.BASE64,
+            ProfileFormat.SIP008
+        )
+    }
+
+    /**
+     * Check if a format is supported for import
+     *
+     * @param format The format to check
+     * @return true if supported, false otherwise
+     */
+    fun isSupportedFormat(format: ProfileFormat): Boolean {
+        return format in getSupportedImportFormats()
+    }
+}

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/TemplatesBridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/TemplatesBridge.kt
@@ -1,10 +1,13 @@
 package com.github.kr328.clash.core.bridge
 
-import android.content.Context
-import com.github.kr328.clash.core.Clash
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import java.io.File
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Bridge for working with profile templates
@@ -26,7 +29,7 @@ object TemplatesBridge {
     fun getAvailableTemplates(): List<Template> {
         val result = nativeGetAvailableTemplates()
         return try {
-            json.decodeFromString(result)
+            json.decodeFromString<List<Template>>(result)
         } catch (e: Exception) {
             emptyList()
         }
@@ -50,35 +53,6 @@ object TemplatesBridge {
     }
 
     /**
-     * Load template content from assets or custom file
-     */
-    fun getTemplateContent(context: Context, templateId: String, profilePath: String): String {
-        return when (templateId) {
-            "default", "rubundle", "davoyan" -> {
-                // Load from assets
-                context.assets.open("templates/$templateId.yaml").use {
-                    it.bufferedReader().readText()
-                }
-            }
-            "custom" -> {
-                // Load from profile directory
-                val customFile = File(profilePath, "custom-template.yaml")
-                if (customFile.exists()) {
-                    customFile.readText()
-                } else {
-                    // Create default custom template
-                    val defaultTemplate = context.assets.open("templates/default.yaml").use {
-                        it.bufferedReader().readText()
-                    }
-                    customFile.writeText(defaultTemplate)
-                    defaultTemplate
-                }
-            }
-            else -> throw IllegalArgumentException("Unknown template ID: $templateId")
-        }
-    }
-
-    /**
      * Apply template to profile with proxies from subscription
      */
     fun applyTemplateToProfile(
@@ -86,24 +60,11 @@ object TemplatesBridge {
         templateContent: String,
         proxies: List<Map<String, Any>>
     ) {
-        val proxiesJson = json.encodeToString(
-            kotlinx.serialization.builtins.ListSerializer(
-                kotlinx.serialization.builtins.MapSerializer(
-                    kotlinx.serialization.builtins.serializer(),
-                    kotlinx.serialization.json.JsonElement.serializer()
-                )
-            ),
-            proxies.map { map ->
-                map.mapValues { (_, value) ->
-                    when (value) {
-                        is String -> kotlinx.serialization.json.JsonPrimitive(value)
-                        is Number -> kotlinx.serialization.json.JsonPrimitive(value)
-                        is Boolean -> kotlinx.serialization.json.JsonPrimitive(value)
-                        else -> kotlinx.serialization.json.JsonPrimitive(value.toString())
-                    }
-                }
-            }
-        )
+        val normalized = proxies.map { map ->
+            JsonObject(map.mapValues { (_, value) -> toJsonElement(value) })
+        }
+
+        val proxiesJson = json.encodeToString(ListSerializer(JsonObject.serializer()), normalized)
 
         val error = nativeApplyTemplateToProfile(profilePath, templateContent, proxiesJson)
         if (error != null) {
@@ -121,16 +82,14 @@ object TemplatesBridge {
         }
     }
 
-    /**
-     * Save custom template content
-     */
-    fun saveCustomTemplate(profilePath: String, content: String) {
-        // Validate first
-        validateTemplateYAML(content)
-
-        // Save to file
-        val customFile = File(profilePath, "custom-template.yaml")
-        customFile.writeText(content)
+    private fun toJsonElement(value: Any?): JsonElement {
+        return when (value) {
+            null -> JsonPrimitive("")
+            is String -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            is Boolean -> JsonPrimitive(value)
+            else -> JsonPrimitive(value.toString())
+        }
     }
 
     // Native methods
@@ -143,8 +102,4 @@ object TemplatesBridge {
         proxiesJSON: String
     ): String?
     private external fun nativeValidateTemplateYAML(content: String): String?
-
-    init {
-        Clash.load()
-    }
 }

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/TemplatesBridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/TemplatesBridge.kt
@@ -1,0 +1,150 @@
+package com.github.kr328.clash.core.bridge
+
+import android.content.Context
+import com.github.kr328.clash.core.Clash
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/**
+ * Bridge for working with profile templates
+ */
+object TemplatesBridge {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    data class Template(
+        val id: String,
+        val name: String,
+        val description: String,
+        val builtin: Boolean
+    )
+
+    /**
+     * Get list of available templates
+     */
+    fun getAvailableTemplates(): List<Template> {
+        val result = nativeGetAvailableTemplates()
+        return try {
+            json.decodeFromString(result)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    /**
+     * Get current template ID for a profile
+     */
+    fun getCurrentTemplate(profilePath: String): String {
+        return nativeGetCurrentTemplate(profilePath)
+    }
+
+    /**
+     * Set template ID for a profile
+     */
+    fun setCurrentTemplate(profilePath: String, templateId: String) {
+        val error = nativeSetCurrentTemplate(profilePath, templateId)
+        if (error != null) {
+            throw Exception(error)
+        }
+    }
+
+    /**
+     * Load template content from assets or custom file
+     */
+    fun getTemplateContent(context: Context, templateId: String, profilePath: String): String {
+        return when (templateId) {
+            "default", "rubundle", "davoyan" -> {
+                // Load from assets
+                context.assets.open("templates/$templateId.yaml").use {
+                    it.bufferedReader().readText()
+                }
+            }
+            "custom" -> {
+                // Load from profile directory
+                val customFile = File(profilePath, "custom-template.yaml")
+                if (customFile.exists()) {
+                    customFile.readText()
+                } else {
+                    // Create default custom template
+                    val defaultTemplate = context.assets.open("templates/default.yaml").use {
+                        it.bufferedReader().readText()
+                    }
+                    customFile.writeText(defaultTemplate)
+                    defaultTemplate
+                }
+            }
+            else -> throw IllegalArgumentException("Unknown template ID: $templateId")
+        }
+    }
+
+    /**
+     * Apply template to profile with proxies from subscription
+     */
+    fun applyTemplateToProfile(
+        profilePath: String,
+        templateContent: String,
+        proxies: List<Map<String, Any>>
+    ) {
+        val proxiesJson = json.encodeToString(
+            kotlinx.serialization.builtins.ListSerializer(
+                kotlinx.serialization.builtins.MapSerializer(
+                    kotlinx.serialization.builtins.serializer(),
+                    kotlinx.serialization.json.JsonElement.serializer()
+                )
+            ),
+            proxies.map { map ->
+                map.mapValues { (_, value) ->
+                    when (value) {
+                        is String -> kotlinx.serialization.json.JsonPrimitive(value)
+                        is Number -> kotlinx.serialization.json.JsonPrimitive(value)
+                        is Boolean -> kotlinx.serialization.json.JsonPrimitive(value)
+                        else -> kotlinx.serialization.json.JsonPrimitive(value.toString())
+                    }
+                }
+            }
+        )
+
+        val error = nativeApplyTemplateToProfile(profilePath, templateContent, proxiesJson)
+        if (error != null) {
+            throw Exception(error)
+        }
+    }
+
+    /**
+     * Validate template YAML syntax
+     */
+    fun validateTemplateYAML(content: String) {
+        val error = nativeValidateTemplateYAML(content)
+        if (error != null) {
+            throw Exception(error)
+        }
+    }
+
+    /**
+     * Save custom template content
+     */
+    fun saveCustomTemplate(profilePath: String, content: String) {
+        // Validate first
+        validateTemplateYAML(content)
+
+        // Save to file
+        val customFile = File(profilePath, "custom-template.yaml")
+        customFile.writeText(content)
+    }
+
+    // Native methods
+    private external fun nativeGetAvailableTemplates(): String
+    private external fun nativeGetCurrentTemplate(profilePath: String): String
+    private external fun nativeSetCurrentTemplate(profilePath: String, templateId: String): String?
+    private external fun nativeApplyTemplateToProfile(
+        profilePath: String,
+        templateContent: String,
+        proxiesJSON: String
+    ): String?
+    private external fun nativeValidateTemplateYAML(content: String): String?
+
+    init {
+        Clash.load()
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/PropertiesDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/PropertiesDesign.kt
@@ -21,6 +21,8 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
     sealed class Request {
         object Commit : Request()
         object BrowseFiles : Request()
+        object SelectTemplate : Request()
+        object EditCustomTemplate : Request()
     }
 
     private val binding = DesignPropertiesBinding
@@ -33,6 +35,12 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
         get() = binding.profile!!
         set(value) {
             binding.profile = value
+        }
+
+    var selectedTemplateName: String = context.getString(R.string.template_default)
+        set(value) {
+            field = value
+            binding.invalidateAll()
         }
 
     val progressing: Boolean
@@ -149,6 +157,14 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
 
     fun requestBrowseFiles() {
         requests.trySend(Request.BrowseFiles)
+    }
+
+    fun requestSelectTemplate() {
+        requests.trySend(Request.SelectTemplate)
+    }
+
+    fun requestEditCustomTemplate() {
+        requests.trySend(Request.EditCustomTemplate)
     }
 
     private fun ModelProgressBarConfigure.applyFrom(status: FetchStatus) {

--- a/design/src/main/res/layout/design_properties.xml
+++ b/design/src/main/res/layout/design_properties.xml
@@ -88,6 +88,26 @@
                     app:text="@{profile.interval == 0 ? @string/disabled : @string/format_minutes(profile.interval / 1000 / 60)}"
                     app:title="@string/auto_update" />
 
+
+
+                <com.github.kr328.clash.design.view.ActionLabel
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/properties_element_margin_vertical"
+                    android:onClick="@{() -> self.requestSelectTemplate()}"
+                    app:icon="@drawable/ic_outline_article"
+                    app:subtext="@{self.selectedTemplateName}"
+                    app:text="@string/template" />
+
+                <com.github.kr328.clash.design.view.ActionLabel
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/properties_element_margin_vertical"
+                    android:onClick="@{() -> self.requestEditCustomTemplate()}"
+                    app:icon="@drawable/ic_outline_article"
+                    app:subtext="@string/custom_template_hint"
+                    app:text="@string/edit_custom_template" />
+
                 <com.github.kr328.clash.design.view.ActionLabel
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -227,7 +227,18 @@
     <string name="meta_github_url" translatable="false">https://github.com/MetaCubeX/ClashMetaForAndroid</string>
     <string name="clash_meta_core_url" translatable="false">https://github.com/MetaCubeX/Clash.Meta</string>
 
-    <string name="tips_properties"><![CDATA[Accept Only <strong>Prizrak-Box Config</strong>(including <strong>Proxy</strong>/<strong>Rules</strong>)]]></string>
+    
+    <string name="template">Template</string>
+    <string name="template_default">Default</string>
+    <string name="template_rubundle">RU Bundle</string>
+    <string name="template_davoyan">Davoyan</string>
+    <string name="template_custom">Custom</string>
+    <string name="template_select_title">Select template</string>
+    <string name="edit_custom_template">Edit custom template</string>
+    <string name="custom_template_hint">Used when template is set to Custom</string>
+    <string name="template_saved">Template updated</string>
+    <string name="custom_template_saved">Custom template saved</string>
+<string name="tips_properties"><![CDATA[Accept Only <strong>Prizrak-Box Config</strong>(including <strong>Proxy</strong>/<strong>Rules</strong>)]]></string>
     <string name="tips_help"><![CDATA[Prizrak-Box is a <strong>freeware</strong> and we do <strong>NOT</strong> provide any service for it]]></string>
 
     <string name="google_play_url" translatable="false">https://play.google.com/store/apps/details?id=com.github.kr328.clash</string>


### PR DESCRIPTION
### Motivation
- Complete Stage 3 template integration by providing real builtin content for `rubundle` and `davoyan` so non-default template IDs no longer fall back to the `default` template at runtime.
- Ensure templates available in `app/src/main/assets/templates/*.yaml` are mirrored in the native Go layer for use during profile import and template application.

### Description
- Added `TemplateRubundleContent` and `TemplateDavoyanContent` constants containing the full YAML content in `core/src/main/golang/native/config/templates_embedded.go`.
- Updated `GetBuiltinTemplateContent(templateID TemplateID)` to return `TemplateRubundleContent` and `TemplateDavoyanContent` for `rubundle`/`davoyan` instead of falling back to `default`.
- Kept `default` template constant and preserved the fallback behavior only for unknown IDs; changes are committed under the message "Embed rubundle and davoyan builtin templates".

### Testing
- Attempted `go test ./native/config`, which failed in this environment due to blocked access to the Go module proxy (`proxy.golang.org`), so unit tests could not complete.
- Attempted `./gradlew --no-daemon app:assembleAlphaRelease`, which failed early in this environment with an SDK/build-tool error (`25.0.1`) before reaching the native/app compile step.
- No further automated test failures related to the template code were observed in the local edits; CI/build validation should be re-run in an environment with external module and Android SDK access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698c66fefbb0832da79695242935b92d)